### PR TITLE
filter-in only public methods out of getDeclaredMethods

### DIFF
--- a/src/main/scala/Backend.scala
+++ b/src/main/scala/Backend.scala
@@ -37,6 +37,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.collection.mutable.Stack
 import scala.collection.mutable.HashSet
 import scala.collection.mutable.HashMap
+import java.lang.reflect.Modifier._
 
 object Backend {
   var moduleNamePrefix = ""
@@ -69,13 +70,17 @@ abstract class Backend {
   def nameChildren(root: Component) {
     // Name all nodes at this level
     root.io.nameIt("io");
-    // We are going through all declarations, which can return Nodes,
-    // ArrayBuffer[Node], Cell, BlackBox and Components.
     val nameSpace = new HashSet[String];
+    /* We are going through all declarations, which can return Nodes,
+     ArrayBuffer[Node], Cell, BlackBox and Components.
+     Since we call invoke() to get a proper instance of the correct type,
+     we have to insure the method is accessible, thus all fields
+     that will generate C++ or Verilog code must be made public. */
     for (m <- root.getClass().getDeclaredMethods) {
       val name = m.getName();
       val types = m.getParameterTypes();
-      if (types.length == 0 && name != "test") {
+      if (types.length == 0
+        && isPublic(m.getModifiers()) && !(Component.keywords contains name)) {
         val o = m.invoke(root);
         o match {
          case node: Node => {

--- a/src/test/scala/NameTest.scala
+++ b/src/test/scala/NameTest.scala
@@ -860,13 +860,19 @@ endmodule
 class NameSuite_DebugComp_1_t : public mod_t {
  public:
   dat_t<1> NameSuite_DebugComp_1_dpath__reset;
+  dat_t<1> NameSuite_DebugComp_1_dpath__reset__prev;
   dat_t<1> NameSuite_DebugComp_1__io_ctrl_wb_wen;
+  dat_t<1> NameSuite_DebugComp_1__io_ctrl_wb_wen__prev;
   dat_t<1> NameSuite_DebugComp_1_dpath__io_ctrl_wb_wen;
+  dat_t<1> NameSuite_DebugComp_1_dpath__io_ctrl_wb_wen__prev;
   dat_t<1> NameSuite_DebugComp_1_dpath__wb_wen;
   dat_t<1> NameSuite_DebugComp_1_dpath__wb_reg_ll_wb;
   dat_t<1> NameSuite_DebugComp_1_dpath__wb_reg_ll_wb_shadow;
+  dat_t<1> NameSuite_DebugComp_1_dpath__wb_reg_ll_wb__prev;
   dat_t<1> NameSuite_DebugComp_1_dpath__io_ctrl_out;
+  dat_t<1> NameSuite_DebugComp_1_dpath__io_ctrl_out__prev;
   dat_t<1> NameSuite_DebugComp_1__io_ctrl_out;
+  dat_t<1> NameSuite_DebugComp_1__io_ctrl_out__prev;
 
   void init ( bool rand_init = false );
   void clock_lo ( dat_t<1> reset );


### PR DESCRIPTION
to support lazy declarations in Component subclasses as generated by scala 2.10
