### PR TITLE
Fix documentation numbering

### DIFF
--- a/doc/getting-started/installation-guts.tex
+++ b/doc/getting-started/installation-guts.tex
@@ -78,12 +78,13 @@ This will run a test build and will take a minute before it completes. If your s
 \section{The Tutorials}
 
 For these tutorials, we assume basic knowledge of digital circuits and blocks. 
-Tutorial 1 will guide you through a quick compilation of the emulator and Verilog generation, and explain some basic constructs such as register and combinational logic. 
-Tutorial 2 will explain how to use basic primitive types and logical operations that are used in Chisel and how to use them in context of several examples. 
-Tutorial 3 will explain how to instantiate components and apply parametrization. 
-Tutorial 4 will explain how to use the Chisel test harness. 
-Tutorial 5 will explain how to set up your own Chisel project and how to build it.
-Tutorial 6 will revisit conditional register updates and explain how to construct memories.
-Finally, tutorial 7 will introduce how to use Scala constructs such as \verb+if...else+ and \verb+for+ loops.
+Tutorial 1 will guide you through a quick compilation of the emulator and Verilog generation, and explain some basic constructs such as register and combinational logic.
+Tutorial 2 will explain the basics of Chisel.
+Tutorial 3 will explain how to use basic primitive types and logical operations that are used in Chisel and how to use them in context of several examples. 
+Tutorial 4 will explain how to instantiate components and apply parametrization. 
+Tutorial 5 will explain how to use the Chisel test harness. 
+Tutorial 6 will explain how to set up your own Chisel project and how to build it.
+Tutorial 7 will revisit conditional register updates and explain how to construct memories.
+Finally, tutorial 8 will introduce how to use Scala constructs such as \verb+if...else+ and \verb+for+ loops.
 
 The following set of tutorials were wrutten using the build settings Scala version 2.9.2, build version 1.1, and Chisel version 1.0.


### PR DESCRIPTION
It looks like an additional section was inserted without updating this numbering. I just happened to notice this because I was looking for something in the documentation.
