### PR TITLE
Don't "return 0" in a void function

### DIFF
--- a/csrc/emulator.h
+++ b/csrc/emulator.h
@@ -2135,7 +2135,7 @@ class mod_t {
         }
         setClocks(periods);
       } else if (cmd == "quit") {
-        return 0;
+          return;
       } else {
         fprintf(stderr, "Unknown command: |%s|\n", cmd.c_str());
       }

--- a/src/main/resources/emulator.h
+++ b/src/main/resources/emulator.h
@@ -2135,7 +2135,7 @@ class mod_t {
         }
         setClocks(periods);
       } else if (cmd == "quit") {
-        return 0;
+          return;
       } else {
         fprintf(stderr, "Unknown command: |%s|\n", cmd.c_str());
       }


### PR DESCRIPTION
This was causing my compile to fail, so I just blew away the return
value.  Hopefully that's a sane thing to do...
