### PR TITLE
(Flo) Fix "eq" and "neq" width specification

### DIFF
--- a/src/main/scala/Flo.scala
+++ b/src/main/scala/Flo.scala
@@ -107,8 +107,8 @@ class FloBackend extends Backend {
              case "&"  => "and/" + node.width + " " + emitRef(node.inputs(0)) + " " + emitRef(node.inputs(1))
              case "&&" => "and/" + node.width + " " + emitRef(node.inputs(0)) + " " + emitRef(node.inputs(1))
              case "^"  => "xor/" + node.width + " " + emitRef(node.inputs(0)) + " " + emitRef(node.inputs(1))
-             case "==" => "eq/" + node.width + " " + emitRef(node.inputs(0)) + " " + emitRef(node.inputs(1))
-             case "!=" => "neq/" + node.width + " " + emitRef(node.inputs(0)) + " " + emitRef(node.inputs(1))
+             case "==" => "eq/" + node.inputs(0).width + " " + emitRef(node.inputs(0)) + " " + emitRef(node.inputs(1))
+             case "!=" => "neq/" + node.inputs(0).width + " " + emitRef(node.inputs(0)) + " " + emitRef(node.inputs(1))
            }
          }) + "\n"
 


### PR DESCRIPTION
The meaning of the width paramater in "eq" and "neq" nodes changed at
some point recently -- it used to be that the width was the width of
the input nodes, but now it's the output width.  As the output width
of all comparison operations is always 1 bit, this is pretty useless.

This patch changes back to the old behavior which is both more useful
and works with existing code.
