### PR TITLE
Check for NULL file descriptors before close()

### DIFF
--- a/src/main/scala/Tester.scala
+++ b/src/main/scala/Tester.scala
@@ -207,10 +207,19 @@ class Tester[+T <: Module](val c: T, val isTrace: Boolean = true) {
 
   def endTesting(): Boolean = {
     if (process != null) {
-      puts("quit\n"); testOut.flush();
-      testOut.close()
-      testIn.close()
-      testErr.close()
+      puts("quit\n")
+
+      if (testOut != null) {
+        testOut.flush()
+        testOut.close()
+      }
+      if (testIn != null) {
+        testIn.close()
+      }
+      if (testErr != null) {
+        testErr.close()
+      }
+
       process.destroy()
     }
     ok


### PR DESCRIPTION
I have no idea why this is happening, but I get some SEGVs when trying
to run some code under the test harness.  I figured I'd just be
explicit and test for NULL pointers.  This appears to have made the
failures go away, but they were sporadic so who knows.
