### PR TITLE
Add "--testerSeed <N>" command-line argument

### DIFF
--- a/src/main/scala/Module.scala
+++ b/src/main/scala/Module.scala
@@ -105,6 +105,11 @@ object Module {
   // standard input stream to a file.
   var dumpTestInput = false;
 
+  // Setting this to TRUE will initialize the tester's RNG with the
+  // seed below.
+  var testerSeedValid = false;
+  var testerSeed = 0;
+
   /* Any call to a *Module* constructor without a proper wrapping
    into a Module.apply() call will be detected when trigger is false. */
   var trigger: Boolean = false

--- a/src/main/scala/Tester.scala
+++ b/src/main/scala/Tester.scala
@@ -205,7 +205,7 @@ class Tester[+T <: Module](val c: T, val isTrace: Boolean = true) {
     allGood
   }
 
-  val rnd = new Random()
+  val rnd = if (Module.testerSeedValid) new Random(Module.testerSeed) else new Random()
   var process: Process = null
 
   def startTesting(): Process = {

--- a/src/main/scala/hcl.scala
+++ b/src/main/scala/hcl.scala
@@ -167,6 +167,11 @@ object chiselMain {
         case "--jackDir"  => Module.jackDir = args(i+1); i+=1;  //location of dump or load
         case "--jackLoad" => Module.jackLoad = args(i+1); i+=1; //design.prm file
         case "--dumpTestInput" => Module.dumpTestInput = true;
+        case "--testerSeed" => {
+          Module.testerSeedValid = true
+          Module.testerSeed = args(i+1).toInt
+          i += 1
+        }
         //case "--jDesign" =>  Module.jackDesign = args(i+1); i+=1;
         case any => ChiselError.warning("'" + arg + "' is an unknown argument.");
       }


### PR DESCRIPTION
The Scala tester uses a random number generator that's currently not
seeded.  This leads to non-determinstic tester behavior, which can be
a pain when you're trying to debug something.

This patch adds a "--testerSeed N" command-line option to Chisel.
This sets the RNG's seed to N.  Without this option the old behavior
is retained.
