### PR TITLE
Fix bit_word_funs::neq() for wide nodes

### DIFF
--- a/src/main/resources/emulator.h
+++ b/src/main/resources/emulator.h
@@ -497,13 +497,8 @@ struct bit_word_funs {
     d[0] = 1;
   }
   static void neq (val_t d[], val_t s0[], val_t s1[]) {
-    for (int i = 0; i < nw; i++) {
-      if (s0[i] == s1[i]) {
-        d[0] = 1;
-        return;
-      }
-    }
-    d[0] = 0;
+    eq(d, s0, s1);
+    d[0] = !d[0];
   }
   static void rsha (val_t d[], val_t s0[], int amount, int w) {
     rsha_n(d, s0, amount, nw, w);


### PR DESCRIPTION
It appears that the implementation of this function was just plain
wrong.  I'm assuming nobody noticed it because there are
template-specialized versions of this template for narrow operations
(1, 2, and 3 words wide).  The specialized versions are implemented
correctly.

This really only matters for people who are VCD dumping signals that
are wider than 192 bits, as I don't think that any other code actually
uses this function.
