### PR TITLE
(Flo) Fix a typo that emitted "xorr"

### DIFF
--- a/src/main/scala/Flo.scala
+++ b/src/main/scala/Flo.scala
@@ -89,7 +89,7 @@ class FloBackend extends Backend {
             case "-" => "neg'" + node.inputs(0).width + " " + emitRef(node.inputs(0))
             case "|" => "neq'" + node.inputs(0).width + " " + emitRef(node.inputs(0)) + " " + "0'" + node.inputs(0).width;
             case "&" => "eq'" + node.inputs(0).width + " " + emitRef(node.inputs(0)) + " " + "-1'" + node.inputs(0).width;
-            case "^" => "xorr'" + node.inputs(0).width + " " + emitRef(node.inputs(0))
+            case "^" => "xor'" + node.inputs(0).width + " " + emitRef(node.inputs(0))
           }
          } else {
            o.op match {


### PR DESCRIPTION
At least I think this is a typo -- I'm not sure why these nodes are
special cased.  I've yet to see any references to an "XORR" node, so
I'm assuming that this is an error.
