### PR TITLE
Add "--emitTempNodes" command-line option

### DIFF
--- a/src/main/scala/Module.scala
+++ b/src/main/scala/Module.scala
@@ -115,6 +115,10 @@ object Module {
    into a Module.apply() call will be detected when trigger is false. */
   var trigger: Boolean = false
 
+  // Setting this to TRUE will result in temporary values (ie, nodes
+  // named "T*") to be emited to the VCD file.
+  var emitTempNodes = false;
+
   def apply[T <: Module](c: => T): T = {
     trigger = true
     /* *push* is done in the Module constructor because we don't have

--- a/src/main/scala/Node.scala
+++ b/src/main/scala/Node.scala
@@ -266,10 +266,12 @@ abstract class Node extends nameable {
   def isInObject: Boolean =
     (isIo && (Module.isIoDebug || component == Module.topComponent)) ||
     Module.topComponent.debugs.contains(this) || isPrintArg || isScanArg ||
-    isReg || isUsedByRam || Module.isDebug && !name.isEmpty
+    isReg || isUsedByRam || Module.isDebug && !name.isEmpty ||
+    Module.emitTempNodes
 
   def isInVCD: Boolean = width > 0 &&
-    ((isIo && isInObject) || isReg || (Module.isDebug && !name.isEmpty))
+    ((isIo && isInObject) || isReg || (Module.isDebug && !name.isEmpty)) ||
+    Module.emitTempNodes
 
   /** Prints all members of a node and recursively its inputs up to a certain
     depth level. This method is purely used for debugging. */

--- a/src/main/scala/hcl.scala
+++ b/src/main/scala/hcl.scala
@@ -183,6 +183,10 @@ object chiselMain {
           Module.testerSeed = args(i+1).toInt
           i += 1
         }
+        case "--emitTempNodes" => {
+            Module.isDebug = true
+            Module.emitTempNodes = true
+        }
         //case "--jDesign" =>  Module.jackDesign = args(i+1); i+=1;
 	// Dreamer configuration flags
 	case "--numRows" => {


### PR DESCRIPTION
As part of verifying the correctness of the LLVM backend I am
currently running a diff between the VCDs that Chisel's C++ backend
emits and those that my toolchain emits.  For some larger designs
there is so much computation that goes on inside temporary nodes it's
a bit hard to figure out exactly what's going on without them in the
VCD file.

This patch adds an "--emitTempNodes" command-line option, which emits
these temporary nodes into the VCD file.  Note that "--emitTempNodes"
implies "--debug" since it feels silly to emit these temporary nodes
without emiting the rest of the internal nodes.

This probably isn't that useful for users, but I can see how it'd be
nice for debugging Chisel internals.
