### PR TITLE
Don't emit empty "_chisel_temps_" VCD module

### DIFF
--- a/src/main/scala/Vcd.scala
+++ b/src/main/scala/Vcd.scala
@@ -87,7 +87,8 @@ class VcdBackend(top: Module) extends Backend {
     if (Module.isVCD) {
       write("  fputs(\"$timescale 1ps $end\\n\", f);\n")
       dumpVCDScope(top, write)
-      dumpScopeForTemps(write)
+      if (Module.emitTempNodes)
+        dumpScopeForTemps(write)
       write("  fputs(\"$enddefinitions $end\\n\", f);\n")
       write("  fputs(\"$dumpvars\\n\", f);\n")
       write("  fputs(\"$end\\n\", f);\n")

--- a/src/test/resources/NameSuite_DebugComp_1.cpp
+++ b/src/test/resources/NameSuite_DebugComp_1.cpp
@@ -26,8 +26,6 @@ void NameSuite_DebugComp_1_t::dump_init(FILE *f) {
   fputs("$var wire 1 \x25 io_ctrl_out $end\n", f);
   fputs("$upscope $end\n", f);
   fputs("$upscope $end\n", f);
-  fputs("$scope module _chisel_temps_ $end\n", f);
-  fputs("$upscope $end\n", f);
   fputs("$enddefinitions $end\n", f);
   fputs("$dumpvars\n", f);
   fputs("$end\n", f);


### PR DESCRIPTION
Jim Lawson suggested this fix, but for some reason I seem to have
dropped the ball and not actually committed it...
