### PR TITLE
Avoid emiting unnamed registers to the VCD file

### DIFF
--- a/src/main/scala/Node.scala
+++ b/src/main/scala/Node.scala
@@ -267,7 +267,7 @@ abstract class Node extends nameable {
 
   def isInVCD: Boolean = name != "reset" && width > 0 &&
      (!name.isEmpty || Module.emitTempNodes) &&
-     ((isIo && isInObject) || isReg || Module.isDebug)
+     ((isIo && isInObject) || (isReg && !name.isEmpty) || Module.isDebug)
 
   /** Prints all members of a node and recursively its inputs up to a certain
     depth level. This method is purely used for debugging. */


### PR DESCRIPTION
If you have a Chisel circuit that generates unnamed registers then
those values will be emited to the VCD file's body (where they're
indexed by short name) without having emited their cooresponding long
names to the VCD file's header (where short names are mapped to long
names).

For example, the following code

```
class test extends Module {
  val io = new Bundle {
    val o = UInt(OUTPUT, width = 32)
  }

  def mkcounter() = {
    val r = Reg(init = UInt(0, width = 32))
    r := r + UInt(1)
    r
  }

  io.o := mkcounter()
}
```

will emit the following VCD file

```
$timescale 1ps $end
$scope module test $end
$var wire 1 N0 reset $end
$var wire 32 N2 io_o $end
$upscope $end
$enddefinitions $end
$dumpvars
$end
#0
b00000000000000000000000000000001 N1
b00000000000000000000000000000000 N2
```

where you can see that the "N1" node doesn't have a cooresponding line
in the VCD header.

While I'm not 100% sure this is out of the VCD specification, it
certainly feels like a bad idea.  In addition it breaks my "vcddiff"
tool that I'm using to verify the correctness of my LLVM backend, so
I'd like it fixed.

This patch fixes the problem by applying the same check
("!name.isEmpty") that's used to ensure that the register is actually
named before outputing it to the VCD file.  I think this is sane: if
you want the register then pass "--emitTempNodes" and the generated
source will contain all temporary nodes (both registers and wires).
