### PR TITLE
Fix VCD dumps

### DIFF
--- a/src/main/scala/Vcd.scala
+++ b/src/main/scala/Vcd.scala
@@ -92,8 +92,11 @@ class VcdBackend(top: Module) extends Backend {
       write("  fputs(\"$dumpvars\\n\", f);\n")
       write("  fputs(\"$end\\n\", f);\n")
       write("  fputs(\"#0\\n\", f);\n")
-      for (i <- 0 until sortedMods.length)
+      for (i <- 0 until sortedMods.length) {
         write(emitDefUnconditional(sortedMods(i), i))
+        val ref = emitRef(sortedMods(i))
+        write("  " + ref + "__prev = " + ref +";\n");
+      }
     }
     write("}\n")
   }


### PR DESCRIPTION
WIRE__prev was not getting set during the first cycle's VCD dump,
which can result in inconsistent VCD dumps.  Essentially the idea is
that if your circuit has a wire that starts as non-zero and becomes
zero after the first cycle, the VCD dump will never reflect this
change.
