### PR TITLE
Fix build related to emitTempNodes

### DIFF
--- a/src/main/scala/Vcd.scala
+++ b/src/main/scala/Vcd.scala
@@ -87,7 +87,7 @@ class VcdBackend(top: Module) extends Backend {
     if (Driver.isVCD) {
       write("  fputs(\"$timescale 1ps $end\\n\", f);\n")
       dumpVCDScope(top, write)
-      if (Module.emitTempNodes)
+      if (Driver.emitTempNodes)
         dumpScopeForTemps(write)
       write("  fputs(\"$enddefinitions $end\\n\", f);\n")
       write("  fputs(\"$dumpvars\\n\", f);\n")


### PR DESCRIPTION
Apparently these global flags changed from Module to Driver.  The
problematic commit came from an old pull request from before this
change.
