### PR TITLE
Reset in multiclock domain inheritance

### DIFF
--- a/src/main/scala/Module.scala
+++ b/src/main/scala/Module.scala
@@ -448,12 +448,8 @@ abstract class Module(var clock: Clock = null, private var _reset: Bool = null) 
             val reset = 
               if (x.component.hasExplicitReset)
                 x.component._reset
-              else if (x.clock != null)
-                x.clock.getReset
-              else if (x.component.hasExplicitClock)
-                x.component.clock.getReset
-              else
-                x.component._reset
+              else 
+                clock.getReset
             x.inputs += x.component.getResetPin(reset)
           }
           x.clock = clock


### PR DESCRIPTION
Hi,

The following was the original code (find the reset pin of each register) :

``` scala
val reset = 
  if (x.component.hasExplicitReset)
    x.component._reset
  else if (x.clock != null)
    x.clock.getReset
  else if (x.component.hasExplicitClock)
    x.component.clock.getReset
  else
    x.component._reset
```

The bad side of this code is :

``` scala
  else if (x.component.hasExplicitClock)
    x.component.clock.getReset
```

That's not recursive, i think that it must find the first parent component that has an explicite clock and take it. Actually that just looks at the current component.
The effect of actual code is:
When you have a module with an explicite clock (with specific reset), and you instanciate a kind module without clock specification => the kind module uses the parent clock, but the kind's reset is not the reset of the parent's clock ! (because the actual code doesn't search parent module's explicit clocks)

Maybe I have missed some cases that made my file change proposition wrong or perhaps the actual behavior is actually wanted. If it's the case, give me a feedback please.

Have a happy day
