### PR TITLE
Preserve top-level module IOs in C++ backend output

### DIFF
--- a/src/main/scala/Module.scala
+++ b/src/main/scala/Module.scala
@@ -303,12 +303,9 @@ abstract class Module(var clock: Clock = null, private var _reset: Bool = null) 
       res.enqueue(a)
     for(b <- Driver.blackboxes)
       res.enqueue(b.io)
-    for(c <- Driver.components) {
-      for((n, io) <- c.io.flatten) {
-        println(io.name)
+    for(c <- Driver.components)
+      for((n, io) <- c.io.flatten)
         res.enqueue(io)
-      }
-    }
 
     res
   }


### PR DESCRIPTION
This changes only `findRoots`, which is sufficient to cause top-level IOs to never be trimmed from the C++ backend output.
