### PR TITLE
Extend clock capabilities

### DIFF
--- a/src/main/scala/Backend.scala
+++ b/src/main/scala/Backend.scala
@@ -261,6 +261,8 @@ abstract class Backend {
     node match {
       case r: Reg =>
         if (r.name == "") "R" + r.emitIndex else r.name
+      case c: Clock => 
+        c.getClockingSource().name
       case _ =>
         if(node.name == "") {
           "T" + node.emitIndex

--- a/src/main/scala/Clock.scala
+++ b/src/main/scala/Clock.scala
@@ -32,14 +32,42 @@ package Chisel
 
 import scala.collection.mutable.ArrayBuffer
 
+object Clock{
+   //clockingSource == null => Get the current module as clock provider
+  def apply(clockingSource : Clock,reset: Bool) : Clock = {
+    val clock = new Clock(reset)
+    clock.setClockingSource(clockingSource);
+
+    clock
+  }
+}
+
+
 class Clock(reset: Bool = Driver.implicitReset) extends Node {
   val stateElms = new ArrayBuffer[Node]
   Driver.clocks += this
   init("", 1)
 
+  var hasClockingSource : Boolean = false 
+  var clockingSource : Clock = null; 
+
+  //if clockingSource == null    =>    take clock of current module   (getClockingSource)
+  def setClockingSource(clockingSource : Clock){
+    hasClockingSource = true;
+    this.clockingSource = clockingSource;
+  }
+	  
   var srcClock: Clock = null
   var initStr = ""
 
+    
+  def getClockingSource() : Clock = {
+    if(hasClockingSource == false) return this
+    if(clockingSource != null) return clockingSource.getClockingSource()
+    if(component != null) return component.clock
+	return null;
+  }  
+  
   // returns a reset pin connected to reset for the component in scope
   def getReset: Bool = {
     if (Driver.compStack.length != 0) {

--- a/src/main/scala/Driver.scala
+++ b/src/main/scala/Driver.scala
@@ -88,10 +88,10 @@ object Driver {
 
   def setTopComponent(mod: Module): Unit = {
     topComponent = mod
-    implicitReset.component = Driver.topComponent
-    implicitClock.component = Driver.topComponent
-    topComponent.reset = Driver.implicitReset
-    topComponent.hasExplicitReset = true
+    //implicitReset.component = Driver.topComponent
+    //implicitClock.component = Driver.topComponent
+    //topComponent.reset = Driver.implicitReset
+    //topComponent.hasExplicitReset = true
     topComponent.clock = Driver.implicitClock
     topComponent.hasExplicitClock = true    
   }
@@ -129,7 +129,7 @@ object Driver {
     implicitReset = Bool(INPUT)
     implicitReset.isIo = true
     implicitReset.setName("reset")
-    implicitClock = new Clock()
+    implicitClock = new Clock(implicitReset)
     implicitClock.setName("clk")
     nodes.clear()
     isInGetWidth = false

--- a/src/main/scala/Module.scala
+++ b/src/main/scala/Module.scala
@@ -178,7 +178,10 @@ abstract class Module(var clock: Clock = null, private var _reset: Bool = null) 
     _reset = r
   }
   def reset_=() {
-    _reset = parent._reset
+    if(parent != null)
+      _reset = parent._reset
+	else
+	  _reset = Driver.implicitReset
   }
 
   override def toString = this.getClass.toString
@@ -450,22 +453,22 @@ abstract class Module(var clock: Clock = null, private var _reset: Bool = null) 
   // clock is chosen to be the component's clock if delay does not specify a clock
   // reset is chosen to be 
   //          component's explicit reset
-  //          delay's explicit clock's reset
-  //          component's clock's reset
+  //          delay's explicit or inferred clock's reset
   def addClockAndReset {
     bfs { _ match {
         case x: Delay =>
           val clock = if (x.clock == null) x.component.clock else x.clock
           val clockingSource = clock.getClockingSource()
           val reset =
-            /*if (x.component.hasExplicitReset) x.component._reset
-            else if (x.clock != null) x.clock.getReset
-            else if (x.component.hasExplicitClock) x.component.clock.getReset
-            else x.component._reset*/
             if (x.component.hasExplicitReset) x.component._reset //legacy hasExplicitReset ?
             else clock.getReset
-            
-          x.assignReset(x.component.addResetPin(reset))
+
+          if(x.component != clock.component){
+            x.assignReset(x.component.addResetPin(reset))
+          } else {
+            x.assignReset(reset) //Don't add reset pin for module who create the clock
+          }  
+          
           x.assignClock(clockingSource)
           x.component.addClock(clockingSource)
         case _ =>

--- a/src/main/scala/Module.scala
+++ b/src/main/scala/Module.scala
@@ -456,14 +456,18 @@ abstract class Module(var clock: Clock = null, private var _reset: Bool = null) 
     bfs { _ match {
         case x: Delay =>
           val clock = if (x.clock == null) x.component.clock else x.clock
+          val clockingSource = clock.getClockingSource()
           val reset =
-            if (x.component.hasExplicitReset) x.component._reset
+            /*if (x.component.hasExplicitReset) x.component._reset
             else if (x.clock != null) x.clock.getReset
             else if (x.component.hasExplicitClock) x.component.clock.getReset
-            else x.component._reset
+            else x.component._reset*/
+            if (x.component.hasExplicitReset) x.component._reset //legacy hasExplicitReset ?
+            else clock.getReset
+            
           x.assignReset(x.component.addResetPin(reset))
-          x.assignClock(clock)
-          x.component.addClock(clock)
+          x.assignClock(clockingSource)
+          x.component.addClock(clockingSource)
         case _ =>
       }
     }

--- a/src/main/scala/Node.scala
+++ b/src/main/scala/Node.scala
@@ -359,7 +359,12 @@ abstract class Node extends nameable {
         }
         i += 1;
       }
-      comp.mods += this;
+            
+      //This dont add to mods the node when it is already into comp.resets list
+      //Maybe it's not a nice way to do that
+      if(! this.isInstanceOf[Bool] || ! comp.resets.contains(this.asInstanceOf[Bool])){
+        comp.mods += this;
+      }
     }
   }
 


### PR DESCRIPTION
Allow the following
```scala
//Standard chisel
val clockA = new Clock(resetA);
//Create a clock domaine with clockA as clock and resetB as reset
val clockA_with_resetB = Clock(clockA,resetB); 
//create clock domaine with current default clock (clk) and resetC
val resetC = Reg(Bool())
resetC := ...
val clk_with_resetC = Clock(null,resetC); 
```
Now  _reset from Module is not removed, but you never again should not need it.
The why is here : https://groups.google.com/forum/#!topic/chisel-users/dW3hLgie9us

I have try to be the less intrusive possible in chisel code to don't add bugs and border effect.
If you find wrong thing in this pull request, give me feed back, and i do a second iteration.

