### PR TITLE
Add Repeat object to standard library

### DIFF
--- a/src/main/scala/ChiselUtil.scala
+++ b/src/main/scala/ChiselUtil.scala
@@ -544,3 +544,10 @@ object PriorityEncoderOH
   }
   def apply(in: Bits): UInt = encode((0 until in.getWidth).map(i => in(i)))
 }
+
+object Repeat
+{
+  def apply[T <: Bits](in: T, n: Int): UInt = {
+    Cat((0 until n).map { _ => in })
+  }
+}

--- a/src/test/scala/StdlibTest.scala
+++ b/src/test/scala/StdlibTest.scala
@@ -736,4 +736,19 @@ try {
       "--targetDir", dir.getPath.toString()),
       () => Module(new MuxComp()))
   }
+
+  @Test def testRepeat() {
+    println("\ntestRepeat ...")
+    class RepeatComp extends Module {
+      val io = new Bundle {
+        val a = UInt(INPUT, 8)
+        val out = UInt(OUTPUT)
+      }
+      io.out := Repeat(io.a, 4)
+    }
+
+    chiselMain(Array[String]("--v",
+      "--targetDir", dir.getPath.toString()),
+      () => Module(new RepeatComp()))
+  }
 }


### PR DESCRIPTION
I've several times wanted to express a "repeat" pattern in chisel, in which a single signal is duplicated N times and concatenated together. This would be equivalent to `{N {sig}}` in Verilog or `(N-1 downto 0) => sig` in VHDL. There are several ways to do this in Chisel using Scala meta-programming, but I think it would be useful to simply add it to the standard library. That way, you could do something like

```
Repeat(UInt(1, 1), 8)
```

And get a byte with all the bits initialized to 1.
