### PR TITLE
Make sure poke and expect assign aggregates in proper order

### DIFF
--- a/src/main/scala/Tester.scala
+++ b/src/main/scala/Tester.scala
@@ -355,7 +355,7 @@ class ManualTester[+T <: Module]
   }
 
   def poke(data: Aggregate, x: Array[BigInt]): Unit = {
-    val kv = (data.flatten.map(x => x._2), x).zipped;
+    val kv = (data.flatten.map(x => x._2), x.reverse).zipped;
     for ((x, y) <- kv)
       poke(x, y)
   }
@@ -408,7 +408,7 @@ class ManualTester[+T <: Module]
   }
 
   def expect (data: Aggregate, expected: Array[BigInt]): Boolean = {
-    val kv = (data.flatten.map(x => x._2), expected).zipped;
+    val kv = (data.flatten.map(x => x._2), expected.reverse).zipped;
     var allGood = true
     for ((d, e) <- kv)
       allGood = expect(d, e) && allGood

--- a/src/test/scala/ConnectTest.scala
+++ b/src/test/scala/ConnectTest.scala
@@ -252,4 +252,47 @@ class ConnectSuite extends TestSuite {
     assertTrue(!ChiselError.ChiselErrors.isEmpty);
   }
 
+  @Test def testVecInput() {
+    class VecInput extends Module {
+      val io = new Bundle {
+        val in = Vec.fill(2){ UInt(INPUT, 8) }
+        val out0 = UInt(OUTPUT, 8)
+        val out1 = UInt(OUTPUT, 8)
+      }
+      io.out0 := io.in(0)
+      io.out1 := io.in(1)
+    }
+
+    class VecInputTests(c: VecInput) extends Tester(c) {
+      poke(c.io.in, Array[BigInt](0, 1))
+      step(1)
+      expect(c.io.out0, 0)
+      expect(c.io.out1, 1)
+    }
+
+    launchCppTester((m: VecInput) => new VecInputTests(m))
+  }
+
+  @Test def testVecOutput() {
+    class VecOutput extends Module {
+      val io = new Bundle {
+        val in0 = UInt(INPUT, 8)
+        val in1 = UInt(INPUT, 8)
+        val out = Vec.fill(2){ UInt(OUTPUT, 8) }
+      }
+
+      io.out(0) := io.in0
+      io.out(1) := io.in1
+    }
+
+    class VecOutputTests(c: VecOutput) extends Tester(c) {
+      poke(c.io.in0, 0)
+      poke(c.io.in1, 1)
+      step(1)
+      expect(c.io.out, Array[BigInt](0, 1))
+    }
+
+    launchCppTester((m: VecOutput) => new VecOutputTests(m))
+  }
+
 }


### PR DESCRIPTION
Fix for issue #223. The assignment of values to ports in the aggregate `poke` and `expect` methods of the Tester was being reversed. This change fixes that issue and adds a unit test to catch similar issues in the future.
