### PR TITLE
Added --vcdMem option for dumping Memory/ROM state.

### DIFF
--- a/src/main/scala/Driver.scala
+++ b/src/main/scala/Driver.scala
@@ -109,6 +109,7 @@ object Driver {
     isCSE = false
     isIoDebug = true
     isVCD = false
+    isVCDMem = false
     isReportDims = false
     targetDir = "."
     components.clear()
@@ -168,6 +169,7 @@ object Driver {
         case "--ioDebug" => isIoDebug = true
         case "--noIoDebug" => isIoDebug = false
         case "--vcd" => isVCD = true
+        case "--vcdMem" => isVCDMem = true
         case "--v" => backend = new VerilogBackend
         case "--moduleNamePrefix" => Backend.moduleNamePrefix = args(i + 1); i += 1
         case "--inlineMem" => isInlineMem = true
@@ -252,6 +254,7 @@ object Driver {
   var isCSE = false
   var isIoDebug = true
   var isVCD = false
+  var isVCDMem = false
   var isInlineMem = true
   var isGenHarness = false
   var isReportDims = false

--- a/src/main/scala/Mem.scala
+++ b/src/main/scala/Mem.scala
@@ -149,7 +149,7 @@ class Mem[T <: Data](gen: () => T, val n: Int, val seqRead: Boolean, val ordered
 
   def length: Int = n
 
-  // override lazy val isInVCD = false
+  override lazy val isInVCD = Driver.isVCDMem
 
   override def toString: String = "TMEM(" + ")"
 

--- a/src/main/scala/ROM.scala
+++ b/src/main/scala/ROM.scala
@@ -75,6 +75,7 @@ class ROMData(elts: SortedMap[Int, Node], val n: Int) extends Node {
   }
 
   override lazy val isInObject: Boolean = true
+  override lazy val isInVCD: Boolean = Driver.isVCDMem
 }
 
 class ROMRead extends Node {


### PR DESCRIPTION
Before this behavior was the default with no option to turn it off.

Also, as a random aside, we should probably have a place to discuss the meanings of all of the Chisel args, and perhaps unify their names a bit ("debug" and "debugMem" are entirely unrelated). 
