### PR TITLE
Fix long RSH by adding dat_t::operator[](size_t)

### DIFF
--- a/src/main/resources/emulator_mod.h
+++ b/src/main/resources/emulator_mod.h
@@ -1027,6 +1027,9 @@ class dat_t {
     dat_t<n> res = mask<n>(n);
     return res;
   }
+  val_t operator [] (size_t i) {
+      return values[i];
+  }
   dat_t<w> operator + ( dat_t<w> o ) {
     dat_t<w> res;
     bit_word_funs<n_words>::add(res.values, values, o.values, w);


### PR DESCRIPTION
I'm not entirely sure if this is the correct way to fix this, but it
seems to be the least intrusive way of going about it.  For some
reason the multi-word RSH code was emiting some operators that aren't
defined.  I couldn't figure out why, so I just went ahead and added
the operator in.
