### PR TITLE
Fix a code-gen issue related to reinterpret_cast

### DIFF
--- a/src/main/scala/Cpp.scala
+++ b/src/main/scala/Cpp.scala
@@ -168,7 +168,7 @@ class CppBackend extends Backend {
     else s"  {${s.map(" " + _ + ";").reduceLeft(_ + _)}}\n"
   def emitDatRef(x: Node): String =
     if (x.isInObject) emitRef(x)
-    else if (words(x) > 1) s"*reinterpret_cast<dat_t<${x.width}>*>(${emitRef(x)})"
+    else if (words(x) > 1) s"*reinterpret_cast<dat_t<${x.width}>*>(&${emitRef(x)})"
     else if (isLit(x)) s"dat_t<${x.width}>(${emitRef(x)})"
     else s"*reinterpret_cast<dat_t<${x.width}>*>(&${emitRef(x)})"
   def trunc(x: Node): String =


### PR DESCRIPTION
This is actually pretty straight-forward, a single "&" appears to have
simply been dropped from the following commit:

```
commit a05bc928e0835b2022d87955226677e381ff9abc
Author: Andrew Waterman <waterman@eecs.berkeley.edu>
Date:   Sun May 25 21:46:26 2014 -0700

    Support sparse ROMs

    These are useful both for speeding up combinational logic in C++
    and for attaining better synthesis QoR.
```

in case anyone is interested, the following code triggers the error

```
import Chisel._;
object Torture {
  def main(args: Array[String]): Unit = {
    chiselMain(args, () => Module(new Torture()));
  }
}
class Torture extends Module {
  class IO extends Bundle {
    val in0 = Bits(INPUT, width=65);
    val in1 = Bits(INPUT, width=65);
    val out0 = Bits(OUTPUT, width=65);
  }
  val io = new IO();
  val io_in0 = Bits(width = 65);
  io_in0 := io.in0;
  val io_in1 = Bits(width = 65);
  io_in1 := io.in1;
  val Torture2 = Bits(width = 65);
  Torture2 := io_in0 / io_in1;
  io.out0 := Torture2;
}
```

I'm not sure that the emitted code is actually wrong, as I don't know
much about what's going on here.  In other words, it could be correct
in this sparse ROM case, I just don't know how to even generate one.
This passes through the rest of my torture tester tests, so hopefully
it's OK?
