### PR TITLE
Remove a spurious newline from Flo's log2 generation rule

### DIFF
--- a/src/main/scala/Flo.scala
+++ b/src/main/scala/Flo.scala
@@ -114,7 +114,7 @@ class FloBackend extends Backend {
           o.op match {
             case "~" => "not'" + node.inputs(0).width + " " + emitRef(node.inputs(0))
             case "^" => "xorr'" + node.inputs(0).width + " " + emitRef(node.inputs(0))
-            case "Log2" => "log2'" + node.width + " " + emitRef(node.inputs(0)) + "\n"
+            case "Log2" => "log2'" + node.width + " " + emitRef(node.inputs(0))
           }
          } else {
            o.op match {


### PR DESCRIPTION
This is actually pretty straight-forward: there is a '\n' at the end
of the log2 rule, which isn't there anywhere else.  I've already
worked around this in libflo, but I figured I'd just fix it because
it's kind of silly.
