### PR TITLE
Mark mod_api_t::string_comparator::() as const

### DIFF
--- a/src/main/resources/emulator_api.h
+++ b/src/main/resources/emulator_api.h
@@ -587,7 +587,7 @@ protected:
 
 	class string_comparator {
 	public:
-		bool operator()(const char* x, const char* y) {
+		bool operator()(const char* x, const char* y) const {
 			return strcmp(x, y) < 0;
 		}
 	};


### PR DESCRIPTION
When I try to build the C++ generated by Chisel on OSX I get the
following error message:

  ./emulator_api.h:590:8: note: candidate function not viable: 'this'
    argument has type 'const mod_api_t::string_comparator', but method
    is not marked const
                bool operator()(const char\* x, const char\* y) {

I don't know why this isn't happening on other platforms (it appears
to be a pretty straight-forward problem?), but the call is buried
somewhere in the libstdc++ call stack so it's probably somewhat
complicated as to exactly why this need to be const.

Regardless, marking this as const seems to be the Right Thing: there's
not even any member variables, so how could it _not_ be const.

This allows chisel-torture to run on OSX for me.
