### PR TITLE
Avoid extracting bits that don't exist

### DIFF
--- a/src/main/scala/Op.scala
+++ b/src/main/scala/Op.scala
@@ -413,6 +413,11 @@ class Op(val op: String) extends Node {
         val w = max(inputs(0).width, inputs(1).width)
         if (inputs(0).width != w) inputs(0) = inputs(0).matchWidth(w)
         if (inputs(1).width != w) inputs(1) = inputs(1).matchWidth(w)
+      } else if (List(">>", "s>>").contains(op)) {
+        val wl = log2Up(inputs(0).width)
+        val w = 1 << wl
+        if (inputs(0).width != w ) inputs(0) = inputs(0).matchWidth(w )
+        if (inputs(1).width != wl) inputs(1) = inputs(1).matchWidth(wl)
       }
     }
   }


### PR DESCRIPTION
Code such as the following

  class test extends Module {
    val io = new Bundle {
      val data = UInt(INPUT, width = 256)
      val offset = UInt(INPUT, width = 10)
      val bit = UInt(OUTPUT, width = 1)
    }

```
io.bit := io.data(io.offset)
```

  }

is capable of extracting bits that don't exist from a wire.  This
translates into an array access in C++ after multi-word expansion
which in this case results in an out-of-bounds access, whic can SEGV.

This patch works around the problem by extending the input to the
nearest power of two and then computing the shift modulo that power of
two.  This eliminates the undefined behavior in C++ but appears to not
match Verilog (which I think specifies these bits read as 0), which is
a bit hairy.

Note that this happens entirely within chisel, essentially relying on
the backends to optimize this away.

This fixes bug #174
