### PR TITLE
Work around a left-shift code gen issue

### DIFF
--- a/src/main/scala/Cpp.scala
+++ b/src/main/scala/Cpp.scala
@@ -297,7 +297,10 @@ class CppBackend extends Backend {
             res += s"val_t __r = ${bpw} - __s"
             for (i <- 0 until words(o)) {
               val inputWord = wordMangle(o.inputs(0), s"CLAMP(${i}-__w, 0, ${words(o.inputs(0)) - 1})")
-              res += s"val_t __v${i} = MASK(${inputWord}, (${i} >= __w) & (${i} < __w + ${words(o.inputs(0))}))"
+              if (Driver.isDebug == true)
+                res += s"val_t __v${i} = MASK(${inputWord}, (${i} >= __w) & (${i} < __w + ${words(o.inputs(0))}))"
+              else
+                res += s"val_t __v${i} = MASK(${inputWord}.values[0], (${i} >= __w) & (${i} < __w + ${words(o.inputs(0))}))"
               res += s"${emitWordRef(o, i)} = __v${i} << __s | __c"
               res += s"__c = MASK(__v${i} >> __r, __s != 0)"
             }


### PR DESCRIPTION
I don't really understand what's going on here, but this appears to
work around a code gen issue that chisel-torture found a while ago.
It appears that for some reason wordMangle() doesn't do the right
thing when running in non-debug mode, so I just went ahead and worked
around the problem.

I'm pretty sure this is the wrong solution, but I have no idea what
the correct one is.

This fixes chisel bug #239
