### PR TITLE
Allow tracing to be toggled during tester

### DIFF
--- a/src/main/scala/Tester.scala
+++ b/src/main/scala/Tester.scala
@@ -46,13 +46,14 @@ class Snapshot(val t: Int) {
 }
 
 class ManualTester[+T <: Module]
-    (val c: T, val isTrace: Boolean = true) {
+    (val c: T, val isT: Boolean = true) {
   var testIn:  InputStream  = null
   var testOut: OutputStream = null
   var testErr: InputStream  = null
   val sb = new StringBuilder()
   var delta = 0
   var t = 0
+  var isTrace = isT
 
   /**
    * Waits until the emulator streams are ready. This is a dirty hack related


### PR DESCRIPTION
This lets you pick which peeks, pokes, and steps appear as traced. It is convenient to make long tests display more compactly, and doesn't affect the current behavior.
