### PR TITLE
Revert "Work around a left-shift code gen issue"

### DIFF
--- a/src/main/scala/Cpp.scala
+++ b/src/main/scala/Cpp.scala
@@ -297,10 +297,7 @@ class CppBackend extends Backend {
             res += s"val_t __r = ${bpw} - __s"
             for (i <- 0 until words(o)) {
               val inputWord = wordMangle(o.inputs(0), s"CLAMP(${i}-__w, 0, ${words(o.inputs(0)) - 1})")
-              if (Driver.isDebug == true)
-                res += s"val_t __v${i} = MASK(${inputWord}, (${i} >= __w) & (${i} < __w + ${words(o.inputs(0))}))"
-              else
-                res += s"val_t __v${i} = MASK(${inputWord}.values[0], (${i} >= __w) & (${i} < __w + ${words(o.inputs(0))}))"
+              res += s"val_t __v${i} = MASK(${inputWord}, (${i} >= __w) & (${i} < __w + ${words(o.inputs(0))}))"
               res += s"${emitWordRef(o, i)} = __v${i} << __s | __c"
               res += s"__c = MASK(__v${i} >> __r, __s != 0)"
             }


### PR DESCRIPTION
Reverts ucb-bar/chisel#243 - causes c++ compile issues in reference-chip:

```
cd /Users/jrl/noArc/clients/ucb/git/ucb-bar/reference-chip/emulator/
make SBT_FLAGS="-Dsbt.log.noformat=true -DchiselVersion=2.3-SNAPSHOT" CC="gcc-mp-4.8" CXX="g++-mp-4.8" RISCV=/Users/jrl/noArc/clients/ucb/riscv clean all
rm -rf *.o *.a emulator-* emulator-*-debug generated-src generated-src-debug DVEfiles ./output
cd /Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip && java -Xmx2048M -Xss8M -XX:MaxPermSize=128M -jar sbt-launch.jar -Dsbt.log.noformat=true -DchiselVersion=2.3-SNAPSHOT "project rocketchip" "elaborate Top  --noIoDebug --backend c --configInstance rocketchip.DefaultCPPConfig --targetDir emulator/generated-src"
[info] Loading global plugins from /Users/jrl/.sbt/0.13/plugins
[info] Loading project definition from /Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/project
[info] Set current project to rocketchip (in build file:/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/)
[info] Set current project to rocketchip (in build file:/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/)
[info] Updating {file:/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/}hardfloat...
[info] Resolving org.scala-lang#scala-library ;2.10.2 ...
[info] Resolving org.scala-lang#scala-reflect ;2.10.2 ...
[info] Resolving edu.berkeley.cs#chisel_2.10 ;2.3-SNAPSHOT ...
[info] Resolving org.scala-lang#scala-compiler ;2.10.2 ...
[info] Resolving org.scala-lang#jline   ;2.10.2 ...
[info] Resolving org.fusesource.jansi#jansi ;1.4 ...
[info] Done updating.
[info] Updating {file:/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/}uncore...
[info] Resolving org.scala-lang#scala-library ;2.10.2 ...
[info] Resolving edu.berkeley.cs#hardfloat_2.10 ;1.2 ...
[info] Resolving org.scala-lang#scala-reflect ;2.10.2 ...
[info] Resolving edu.berkeley.cs#chisel_2.10 ;2.3-SNAPSHOT ...
[info] Resolving org.scala-lang#scala-compiler ;2.10.2 ...
[info] Resolving org.scala-lang#jline   ;2.10.2 ...
[info] Resolving org.fusesource.jansi#jansi ;1.4 ...
[info] Done updating.
[info] Updating {file:/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/}rocket...
[info] Resolving org.scala-lang#scala-library ;2.10.2 ...
[info] Resolving edu.berkeley.cs#uncore_2.10 ;2.0 ...
[info] Resolving edu.berkeley.cs#hardfloat_2.10 ;1.2 ...
[info] Resolving org.scala-lang#scala-reflect ;2.10.2 ...
[info] Resolving edu.berkeley.cs#chisel_2.10 ;2.3-SNAPSHOT ...
[info] Resolving org.scala-lang#scala-compiler ;2.10.2 ...
[info] Resolving org.scala-lang#jline   ;2.10.2 ...
[info] Resolving org.fusesource.jansi#jansi ;1.4 ...
[info] Done updating.
[info] Updating {file:/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/}rocketchip...
[info] Resolving org.scala-lang#scala-library ;2.10.2 ...
[info] Resolving edu.berkeley.cs#hardfloat_2.10 ;1.2 ...
[info] Resolving org.scala-lang#scala-reflect ;2.10.2 ...
[info] Resolving edu.berkeley.cs#chisel_2.10 ;2.3-SNAPSHOT ...
[info] Resolving edu.berkeley.cs#uncore_2.10 ;2.0 ...
[info] Resolving edu.berkeley.cs#rocket_2.10 ;1.2 ...
[info] Resolving org.scala-lang#scala-compiler ;2.10.2 ...
[info] Resolving org.scala-lang#jline   ;2.10.2 ...
[info] Resolving org.fusesource.jansi#jansi ;1.4 ...
[info] Done updating.
[info] Compiling 12 Scala sources to /Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/hardfloat/target/scala-2.10/classes...
[warn] there were 42 feature warning(s) ; re-run with -feature for details
[warn] one warning found
[info] Compiling 11 Scala sources to /Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/uncore/target/scala-2.10/classes...
[warn] there were 540 feature warning(s) ; re-run with -feature for details
[warn] one warning found
[info] Compiling 21 Scala sources to /Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/rocket/target/scala-2.10/classes...
[warn] there were 1050 feature warning(s) ; re-run with -feature for details
[warn] one warning found
[info] Compiling 63 Scala sources to /Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/target/scala-2.10/classes...
[warn] there were 3478 feature warning(s) ; re-run with -feature for details
[warn] one warning found
CPP elaborate
[[35minfo[0m] [4.497] elaborating modules
       [[35minfo[0m] [4.734] // COMPILING class rocketchip.Top(6)
              [[35minfo[0m] [4.819] inferring widths
                 [[35minfo[0m] [5.454] checking widths
                        [[35minfo[0m] [5.581] lowering complex nodes to primitives
                               [[35minfo[0m] [5.582] removing type nodes
                                  [[35minfo[0m] [5.648] resolving nodes to the components
                                         [[35minfo[0m] [5.747] executing custom transforms
                                            [[35minfo[0m] [6.756] checking for combinational loops
                                                   [[35minfo[0m] [6.894] NO COMBINATIONAL LOOP FOUND
                                                          [[33mwarn[0m] nbdcache.scala:886: UNABLE TO FIND tag IN class Chisel.Arbiter in class rocket.HellaCache
                                                             [[33mwarn[0m] nbdcache.scala:912: UNABLE TO FIND tag IN class Chisel.Arbiter in class rocket.HellaCache
                                                                    [[33mwarn[0m] dpath.scala:181: UNABLE TO FIND evec IN class rocket.Datapath in class rocket.Datapath
                                                                           [[33mwarn[0m] dpath.scala:181: UNABLE TO FIND fatc IN class rocket.Datapath in class rocket.Datapath
                                                                              [[33mwarn[0m] dpath.scala:181: UNABLE TO FIND fcsr_flags IN class rocket.Datapath in class rocket.Datapath
                                                                                     [[33mwarn[0m] dpath.scala:181: UNABLE TO FIND fcsr_rm IN class rocket.Datapath in class rocket.Datapath
                                                                                        [[33mwarn[0m] dpath.scala:181: UNABLE TO FIND host IN class rocket.Datapath in class rocket.Datapath
                                                                                               [[33mwarn[0m] dpath.scala:181: UNABLE TO FIND pc IN class rocket.Datapath in class rocket.Datapath
                                                                                                      [[33mwarn[0m] dpath.scala:181: UNABLE TO FIND ptbr IN class rocket.Datapath in class rocket.Datapath
                                                                                                         [[33mwarn[0m] dpath.scala:181: UNABLE TO FIND replay IN class rocket.Datapath in class rocket.Datapath
                                                                                                                [[33mwarn[0m] dpath.scala:181: UNABLE TO FIND rocc IN class rocket.Datapath in class rocket.Datapath
                                                                                                                       [[33mwarn[0m] dpath.scala:181: UNABLE TO FIND rw IN class rocket.Datapath in class rocket.Datapath
                                                                                                                          [[33mwarn[0m] dpath.scala:181: UNABLE TO FIND time IN class rocket.Datapath in class rocket.Datapath
                                                                                                                                 [[33mwarn[0m] dpath.scala:181: UNABLE TO FIND uarch_counters IN class rocket.Datapath in class rocket.Datapath
                                                                                                                                    [[33mwarn[0m] dpath.scala:182: UNABLE TO FIND badvaddr_wen IN class rocket.Datapath in class rocket.Datapath
                                                                                                                                           [[33mwarn[0m] dpath.scala:182: UNABLE TO FIND cause IN class rocket.Datapath in class rocket.Datapath
                                                                                                                                                  [[33mwarn[0m] dpath.scala:182: UNABLE TO FIND evec IN class rocket.Datapath in class rocket.Datapath
                                                                                                                                                     [[33mwarn[0m] dpath.scala:182: UNABLE TO FIND exception IN class rocket.Datapath in class rocket.Datapath
                                                                                                                                                            [[33mwarn[0m] dpath.scala:182: UNABLE TO FIND fatc IN class rocket.Datapath in class rocket.Datapath
                                                                                                                                                                   [[33mwarn[0m] dpath.scala:182: UNABLE TO FIND host IN class rocket.Datapath in class rocket.Datapath
                                                                                                                                                                      [[33mwarn[0m] dpath.scala:182: UNABLE TO FIND pc IN class rocket.Datapath in class rocket.Datapath
                                                                                                                                                                             [[33mwarn[0m] dpath.scala:182: UNABLE TO FIND ptbr IN class rocket.Datapath in class rocket.Datapath
                                                                                                                                                                                [[33mwarn[0m] dpath.scala:182: UNABLE TO FIND replay IN class rocket.Datapath in class rocket.Datapath
                                                                                                                                                                                       [[33mwarn[0m] dpath.scala:182: UNABLE TO FIND retire IN class rocket.Datapath in class rocket.Datapath
                                                                                                                                                                                              [[33mwarn[0m] dpath.scala:182: UNABLE TO FIND rocc IN class rocket.Datapath in class rocket.Datapath
                                                                                                                                                                                                 [[33mwarn[0m] dpath.scala:182: UNABLE TO FIND rw IN class rocket.Datapath in class rocket.Datapath
                                                                                                                                                                                                        [[33mwarn[0m] dpath.scala:182: UNABLE TO FIND sret IN class rocket.Datapath in class rocket.Datapath
                                                                                                                                                                                                               [[33mwarn[0m] dpath.scala:182: UNABLE TO FIND status IN class rocket.Datapath in class rocket.Datapath
                                                                                                                                                                                                                  [[33mwarn[0m] dpath.scala:182: UNABLE TO FIND time IN class rocket.Datapath in class rocket.Datapath
                                                                                                                                                                                                                         [[33mwarn[0m] dpath.scala:182: UNABLE TO FIND uarch_counters IN class rocket.Datapath in class rocket.Datapath
                                                                                                                                                                                                                            [[33mwarn[0m] llc.scala:549: UNABLE TO FIND ready IN class uncore.DRAMSideLLCNull in class uncore.DRAMSideLLCNull
                                                                                                                                                                                                                                   [[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 128 in class sun.reflect.NativeMethodAccessorImpl
                                                                                                                                                                                                                                          [[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 16 in class sun.reflect.NativeMethodAccessorImpl
                                                                                                                                                                                                                                             [[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
                                                                                                                                                                                                                                                    [[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
                                                                                                                                                                                                                                                           [[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 1 < 42 in class sun.reflect.NativeMethodAccessorImpl
                                                                                                                                                                                                                                                              [[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 5 in class sun.reflect.NativeMethodAccessorImpl
                                                                                                                                                                                                                                                                     [[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 10 in class sun.reflect.NativeMethodAccessorImpl
                                                                                                                                                                                                                                                                        [[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 20 in class sun.reflect.NativeMethodAccessorImpl
                                                                                                                                                                                                                                                                               [[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 42 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 13 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 3 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 1 < 128 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 1 < 16 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 1 < 42 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 1 < 5 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 8 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 16 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 8 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 16 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 8 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 8 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 2 < 13 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 1 < 3 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 1 < 42 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 1 < 5 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 8 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 16 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 8 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 16 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 8 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 8 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 2 < 13 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 1 < 3 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 1 < 42 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 1 < 5 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 8 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 1 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 16 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 8 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 2 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 16 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 4 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 8 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 0 < 8 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 1 < 3 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 1 < 42 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 1 < 5 in class sun.reflect.NativeMethodAccessorImpl
[[33mwarn[0m] NativeMethodAccessorImpl.java:-2: Width.op- setting width to Width(): 3 < 42 in class sun.reflect.NativeMethodAccessorImpl
[success] Total time: 109 s, completed Sep 16, 2014 3:06:41 PM
g++-mp-4.8 -O1 -std=c++11 -I/Users/jrl/noArc/clients/ucb/riscv/include -I/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/csrc -I/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/dramsim2 -include generated-src/Top.DefaultCPPConfig.h -Igenerated-src -c -o emulator.o /Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/csrc/emulator.cc
g++-mp-4.8 -O1 -std=c++11 -I/Users/jrl/noArc/clients/ucb/riscv/include -I/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/csrc -I/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/dramsim2 -include generated-src/Top.DefaultCPPConfig.h -Igenerated-src -c -o mm.o /Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/csrc/mm.cc
g++-mp-4.8 -O1 -std=c++11 -I/Users/jrl/noArc/clients/ucb/riscv/include -I/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/csrc -I/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/dramsim2 -include generated-src/Top.DefaultCPPConfig.h -Igenerated-src -c -o mm_dramsim2.o /Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/csrc/mm_dramsim2.cc
/Applications/Xcode.app/Contents/Developer/usr/bin/make -j generated-src/Top.DefaultCPPConfig-0.o generated-src/Top.DefaultCPPConfig-1.o generated-src/Top.DefaultCPPConfig-2.o generated-src/Top.DefaultCPPConfig-3.o generated-src/Top.DefaultCPPConfig-4.o generated-src/Top.DefaultCPPConfig-5.o
g++-mp-4.8 -O1 -std=c++11 -I/Users/jrl/noArc/clients/ucb/riscv/include -I/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/csrc -I/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/dramsim2   -c -o generated-src/Top.DefaultCPPConfig-0.o generated-src/Top.DefaultCPPConfig-0.cpp
g++-mp-4.8 -O1 -std=c++11 -I/Users/jrl/noArc/clients/ucb/riscv/include -I/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/csrc -I/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/dramsim2   -c -o generated-src/Top.DefaultCPPConfig-1.o generated-src/Top.DefaultCPPConfig-1.cpp
g++-mp-4.8 -O1 -std=c++11 -I/Users/jrl/noArc/clients/ucb/riscv/include -I/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/csrc -I/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/dramsim2   -c -o generated-src/Top.DefaultCPPConfig-2.o generated-src/Top.DefaultCPPConfig-2.cpp
g++-mp-4.8 -O1 -std=c++11 -I/Users/jrl/noArc/clients/ucb/riscv/include -I/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/csrc -I/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/dramsim2   -c -o generated-src/Top.DefaultCPPConfig-3.o generated-src/Top.DefaultCPPConfig-3.cpp
g++-mp-4.8 -O1 -std=c++11 -I/Users/jrl/noArc/clients/ucb/riscv/include -I/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/csrc -I/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/dramsim2   -c -o generated-src/Top.DefaultCPPConfig-4.o generated-src/Top.DefaultCPPConfig-4.cpp
g++-mp-4.8 -O1 -std=c++11 -I/Users/jrl/noArc/clients/ucb/riscv/include -I/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/csrc -I/Volumes/vpbRoad/noArc/clients/ucb/git/ucb-bar/reference-chip/dramsim2   -c -o generated-src/Top.DefaultCPPConfig-5.o generated-src/Top.DefaultCPPConfig-5.cpp
In file included from generated-src/emulator.h:2:0,
                 from generated-src/Top.DefaultCPPConfig.h:4,
                 from generated-src/Top.DefaultCPPConfig-3.cpp:1:
generated-src/Top.DefaultCPPConfig-3.cpp:25862:110: error: hexadecimal floating constants require an exponent
   { val_t __c = 0; val_t __w = T12093 / 64; val_t __s = T12093 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(0x1.values[0], (0 >= __w) & (0 < __w + 1)); T12094[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(0x1.values[0], (1 >= __w) & (1 < __w + 1)); T12094[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0); val_t __v2 = MASK(0x1.values[0], (2 >= __w) & (2 < __w + 1)); T12094[2] = __v2 << __s | __c; __c = MASK(__v2 >> __r, __s != 0); val_t __v3 = MASK(0x1.values[0], (3 >= __w) & (3 < __w + 1)); T12094[3] = __v3 << __s | __c; __c = MASK(__v3 >> __r, __s != 0);}
                                                                                                              ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:25862:238: error: hexadecimal floating constants require an exponent
   { val_t __c = 0; val_t __w = T12093 / 64; val_t __s = T12093 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(0x1.values[0], (0 >= __w) & (0 < __w + 1)); T12094[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(0x1.values[0], (1 >= __w) & (1 < __w + 1)); T12094[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0); val_t __v2 = MASK(0x1.values[0], (2 >= __w) & (2 < __w + 1)); T12094[2] = __v2 << __s | __c; __c = MASK(__v2 >> __r, __s != 0); val_t __v3 = MASK(0x1.values[0], (3 >= __w) & (3 < __w + 1)); T12094[3] = __v3 << __s | __c; __c = MASK(__v3 >> __r, __s != 0);}
                                                                                                                                                                                                                                              ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:25862:366: error: hexadecimal floating constants require an exponent
   { val_t __c = 0; val_t __w = T12093 / 64; val_t __s = T12093 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(0x1.values[0], (0 >= __w) & (0 < __w + 1)); T12094[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(0x1.values[0], (1 >= __w) & (1 < __w + 1)); T12094[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0); val_t __v2 = MASK(0x1.values[0], (2 >= __w) & (2 < __w + 1)); T12094[2] = __v2 << __s | __c; __c = MASK(__v2 >> __r, __s != 0); val_t __v3 = MASK(0x1.values[0], (3 >= __w) & (3 < __w + 1)); T12094[3] = __v3 << __s | __c; __c = MASK(__v3 >> __r, __s != 0);}
                                                                                                                                                                                                                                                                                                                                                                              ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:25862:494: error: hexadecimal floating constants require an exponent
   { val_t __c = 0; val_t __w = T12093 / 64; val_t __s = T12093 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(0x1.values[0], (0 >= __w) & (0 < __w + 1)); T12094[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(0x1.values[0], (1 >= __w) & (1 < __w + 1)); T12094[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0); val_t __v2 = MASK(0x1.values[0], (2 >= __w) & (2 < __w + 1)); T12094[2] = __v2 << __s | __c; __c = MASK(__v2 >> __r, __s != 0); val_t __v3 = MASK(0x1.values[0], (3 >= __w) & (3 < __w + 1)); T12094[3] = __v3 << __s | __c; __c = MASK(__v3 >> __r, __s != 0);}
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:25887:110: error: hexadecimal floating constants require an exponent
   { val_t __c = 0; val_t __w = T12107 / 64; val_t __s = T12107 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(0x1.values[0], (0 >= __w) & (0 < __w + 1)); T12108[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(0x1.values[0], (1 >= __w) & (1 < __w + 1)); T12108[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0); val_t __v2 = MASK(0x1.values[0], (2 >= __w) & (2 < __w + 1)); T12108[2] = __v2 << __s | __c; __c = MASK(__v2 >> __r, __s != 0); val_t __v3 = MASK(0x1.values[0], (3 >= __w) & (3 < __w + 1)); T12108[3] = __v3 << __s | __c; __c = MASK(__v3 >> __r, __s != 0);}
                                                                                                              ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:25887:238: error: hexadecimal floating constants require an exponent
   { val_t __c = 0; val_t __w = T12107 / 64; val_t __s = T12107 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(0x1.values[0], (0 >= __w) & (0 < __w + 1)); T12108[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(0x1.values[0], (1 >= __w) & (1 < __w + 1)); T12108[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0); val_t __v2 = MASK(0x1.values[0], (2 >= __w) & (2 < __w + 1)); T12108[2] = __v2 << __s | __c; __c = MASK(__v2 >> __r, __s != 0); val_t __v3 = MASK(0x1.values[0], (3 >= __w) & (3 < __w + 1)); T12108[3] = __v3 << __s | __c; __c = MASK(__v3 >> __r, __s != 0);}
                                                                                                                                                                                                                                              ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:25887:366: error: hexadecimal floating constants require an exponent
   { val_t __c = 0; val_t __w = T12107 / 64; val_t __s = T12107 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(0x1.values[0], (0 >= __w) & (0 < __w + 1)); T12108[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(0x1.values[0], (1 >= __w) & (1 < __w + 1)); T12108[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0); val_t __v2 = MASK(0x1.values[0], (2 >= __w) & (2 < __w + 1)); T12108[2] = __v2 << __s | __c; __c = MASK(__v2 >> __r, __s != 0); val_t __v3 = MASK(0x1.values[0], (3 >= __w) & (3 < __w + 1)); T12108[3] = __v3 << __s | __c; __c = MASK(__v3 >> __r, __s != 0);}
                                                                                                                                                                                                                                                                                                                                                                              ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:25887:494: error: hexadecimal floating constants require an exponent
   { val_t __c = 0; val_t __w = T12107 / 64; val_t __s = T12107 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(0x1.values[0], (0 >= __w) & (0 < __w + 1)); T12108[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(0x1.values[0], (1 >= __w) & (1 < __w + 1)); T12108[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0); val_t __v2 = MASK(0x1.values[0], (2 >= __w) & (2 < __w + 1)); T12108[2] = __v2 << __s | __c; __c = MASK(__v2 >> __r, __s != 0); val_t __v3 = MASK(0x1.values[0], (3 >= __w) & (3 < __w + 1)); T12108[3] = __v3 << __s | __c; __c = MASK(__v3 >> __r, __s != 0);}
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:25907:110: error: hexadecimal floating constants require an exponent
   { val_t __c = 0; val_t __w = T12118 / 64; val_t __s = T12118 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(0x1.values[0], (0 >= __w) & (0 < __w + 1)); T12119[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(0x1.values[0], (1 >= __w) & (1 < __w + 1)); T12119[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0); val_t __v2 = MASK(0x1.values[0], (2 >= __w) & (2 < __w + 1)); T12119[2] = __v2 << __s | __c; __c = MASK(__v2 >> __r, __s != 0); val_t __v3 = MASK(0x1.values[0], (3 >= __w) & (3 < __w + 1)); T12119[3] = __v3 << __s | __c; __c = MASK(__v3 >> __r, __s != 0);}
                                                                                                              ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:25907:238: error: hexadecimal floating constants require an exponent
   { val_t __c = 0; val_t __w = T12118 / 64; val_t __s = T12118 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(0x1.values[0], (0 >= __w) & (0 < __w + 1)); T12119[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(0x1.values[0], (1 >= __w) & (1 < __w + 1)); T12119[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0); val_t __v2 = MASK(0x1.values[0], (2 >= __w) & (2 < __w + 1)); T12119[2] = __v2 << __s | __c; __c = MASK(__v2 >> __r, __s != 0); val_t __v3 = MASK(0x1.values[0], (3 >= __w) & (3 < __w + 1)); T12119[3] = __v3 << __s | __c; __c = MASK(__v3 >> __r, __s != 0);}
                                                                                                                                                                                                                                              ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:25907:366: error: hexadecimal floating constants require an exponent
   { val_t __c = 0; val_t __w = T12118 / 64; val_t __s = T12118 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(0x1.values[0], (0 >= __w) & (0 < __w + 1)); T12119[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(0x1.values[0], (1 >= __w) & (1 < __w + 1)); T12119[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0); val_t __v2 = MASK(0x1.values[0], (2 >= __w) & (2 < __w + 1)); T12119[2] = __v2 << __s | __c; __c = MASK(__v2 >> __r, __s != 0); val_t __v3 = MASK(0x1.values[0], (3 >= __w) & (3 < __w + 1)); T12119[3] = __v3 << __s | __c; __c = MASK(__v3 >> __r, __s != 0);}
                                                                                                                                                                                                                                                                                                                                                                              ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:25907:494: error: hexadecimal floating constants require an exponent
   { val_t __c = 0; val_t __w = T12118 / 64; val_t __s = T12118 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(0x1.values[0], (0 >= __w) & (0 < __w + 1)); T12119[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(0x1.values[0], (1 >= __w) & (1 < __w + 1)); T12119[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0); val_t __v2 = MASK(0x1.values[0], (2 >= __w) & (2 < __w + 1)); T12119[2] = __v2 << __s | __c; __c = MASK(__v2 >> __r, __s != 0); val_t __v3 = MASK(0x1.values[0], (3 >= __w) & (3 < __w + 1)); T12119[3] = __v3 << __s | __c; __c = MASK(__v3 >> __r, __s != 0);}
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp: In member function 'virtual void Top_t::clock_lo(dat_t<1>)':
generated-src/Top.DefaultCPPConfig-3.cpp:4950:136: error: request for member 'values' in 'T3076[(((((- __w) ^ 1ull) & ((val_t)(-(__w == 0ull)))) ^ 1ull) & ((val_t)(-((((- __w) ^ 1ull) & ((val_t)(-(__w == 0ull)))) != 1ull))))]', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = 0x180L / 64; val_t __s = 0x180L % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T3076[CLAMP(0-__w, 0, 1)].values[0], (0 >= __w) & (0 < __w + 2)); T3077[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T3076[CLAMP(1-__w, 0, 1)].values[0], (1 >= __w) & (1 < __w + 2)); T3077[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0); val_t __v2 = MASK(T3076[CLAMP(2-__w, 0, 1)].values[0], (2 >= __w) & (2 < __w + 2)); T3077[2] = __v2 << __s | __c; __c = MASK(__v2 >> __r, __s != 0); val_t __v3 = MASK(T3076[CLAMP(3-__w, 0, 1)].values[0], (3 >= __w) & (3 < __w + 2)); T3077[3] = __v3 << __s | __c; __c = MASK(__v3 >> __r, __s != 0); val_t __v4 = MASK(T3076[CLAMP(4-__w, 0, 1)].values[0], (4 >= __w) & (4 < __w + 2)); T3077[4] = __v4 << __s | __c; __c = MASK(__v4 >> __r, __s != 0); val_t __v5 = MASK(T3076[CLAMP(5-__w, 0, 1)].values[0], (5 >= __w) & (5 < __w + 2)); T3077[5] = __v5 << __s | __c; __c = MASK(__v5 >> __r, __s != 0); val_t __v6 = MASK(T3076[CLAMP(6-__w, 0, 1)].values[0], (6 >= __w) & (6 < __w + 2)); T3077[6] = __v6 << __s | __c; __c = MASK(__v6 >> __r, __s != 0); val_t __v7 = MASK(T3076[CLAMP(7-__w, 0, 1)].values[0], (7 >= __w) & (7 < __w + 2)); T3077[7] = __v7 << __s | __c; __c = MASK(__v7 >> __r, __s != 0);}
                                                                                                                                        ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:4950:285: error: request for member 'values' in 'T3076[(((((1ull - __w) ^ 1ull) & ((val_t)(-(__w == 1ull)))) ^ 1ull) & ((val_t)(-((((1ull - __w) ^ 1ull) & ((val_t)(-(__w == 1ull)))) != 1ull))))]', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = 0x180L / 64; val_t __s = 0x180L % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T3076[CLAMP(0-__w, 0, 1)].values[0], (0 >= __w) & (0 < __w + 2)); T3077[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T3076[CLAMP(1-__w, 0, 1)].values[0], (1 >= __w) & (1 < __w + 2)); T3077[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0); val_t __v2 = MASK(T3076[CLAMP(2-__w, 0, 1)].values[0], (2 >= __w) & (2 < __w + 2)); T3077[2] = __v2 << __s | __c; __c = MASK(__v2 >> __r, __s != 0); val_t __v3 = MASK(T3076[CLAMP(3-__w, 0, 1)].values[0], (3 >= __w) & (3 < __w + 2)); T3077[3] = __v3 << __s | __c; __c = MASK(__v3 >> __r, __s != 0); val_t __v4 = MASK(T3076[CLAMP(4-__w, 0, 1)].values[0], (4 >= __w) & (4 < __w + 2)); T3077[4] = __v4 << __s | __c; __c = MASK(__v4 >> __r, __s != 0); val_t __v5 = MASK(T3076[CLAMP(5-__w, 0, 1)].values[0], (5 >= __w) & (5 < __w + 2)); T3077[5] = __v5 << __s | __c; __c = MASK(__v5 >> __r, __s != 0); val_t __v6 = MASK(T3076[CLAMP(6-__w, 0, 1)].values[0], (6 >= __w) & (6 < __w + 2)); T3077[6] = __v6 << __s | __c; __c = MASK(__v6 >> __r, __s != 0); val_t __v7 = MASK(T3076[CLAMP(7-__w, 0, 1)].values[0], (7 >= __w) & (7 < __w + 2)); T3077[7] = __v7 << __s | __c; __c = MASK(__v7 >> __r, __s != 0);}
                                                                                                                                                                                                                                                                                             ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:4950:434: error: request for member 'values' in 'T3076[(((((2ull - __w) ^ 1ull) & ((val_t)(-(__w == 2ull)))) ^ 1ull) & ((val_t)(-((((2ull - __w) ^ 1ull) & ((val_t)(-(__w == 2ull)))) != 1ull))))]', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = 0x180L / 64; val_t __s = 0x180L % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T3076[CLAMP(0-__w, 0, 1)].values[0], (0 >= __w) & (0 < __w + 2)); T3077[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T3076[CLAMP(1-__w, 0, 1)].values[0], (1 >= __w) & (1 < __w + 2)); T3077[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0); val_t __v2 = MASK(T3076[CLAMP(2-__w, 0, 1)].values[0], (2 >= __w) & (2 < __w + 2)); T3077[2] = __v2 << __s | __c; __c = MASK(__v2 >> __r, __s != 0); val_t __v3 = MASK(T3076[CLAMP(3-__w, 0, 1)].values[0], (3 >= __w) & (3 < __w + 2)); T3077[3] = __v3 << __s | __c; __c = MASK(__v3 >> __r, __s != 0); val_t __v4 = MASK(T3076[CLAMP(4-__w, 0, 1)].values[0], (4 >= __w) & (4 < __w + 2)); T3077[4] = __v4 << __s | __c; __c = MASK(__v4 >> __r, __s != 0); val_t __v5 = MASK(T3076[CLAMP(5-__w, 0, 1)].values[0], (5 >= __w) & (5 < __w + 2)); T3077[5] = __v5 << __s | __c; __c = MASK(__v5 >> __r, __s != 0); val_t __v6 = MASK(T3076[CLAMP(6-__w, 0, 1)].values[0], (6 >= __w) & (6 < __w + 2)); T3077[6] = __v6 << __s | __c; __c = MASK(__v6 >> __r, __s != 0); val_t __v7 = MASK(T3076[CLAMP(7-__w, 0, 1)].values[0], (7 >= __w) & (7 < __w + 2)); T3077[7] = __v7 << __s | __c; __c = MASK(__v7 >> __r, __s != 0);}
                                                                                                                                                                                                                                                                                                                                                                                                                                                  ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:4950:583: error: request for member 'values' in 'T3076[(((((3ull - __w) ^ 1ull) & ((val_t)(-(__w == 3ull)))) ^ 1ull) & ((val_t)(-((((3ull - __w) ^ 1ull) & ((val_t)(-(__w == 3ull)))) != 1ull))))]', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = 0x180L / 64; val_t __s = 0x180L % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T3076[CLAMP(0-__w, 0, 1)].values[0], (0 >= __w) & (0 < __w + 2)); T3077[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T3076[CLAMP(1-__w, 0, 1)].values[0], (1 >= __w) & (1 < __w + 2)); T3077[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0); val_t __v2 = MASK(T3076[CLAMP(2-__w, 0, 1)].values[0], (2 >= __w) & (2 < __w + 2)); T3077[2] = __v2 << __s | __c; __c = MASK(__v2 >> __r, __s != 0); val_t __v3 = MASK(T3076[CLAMP(3-__w, 0, 1)].values[0], (3 >= __w) & (3 < __w + 2)); T3077[3] = __v3 << __s | __c; __c = MASK(__v3 >> __r, __s != 0); val_t __v4 = MASK(T3076[CLAMP(4-__w, 0, 1)].values[0], (4 >= __w) & (4 < __w + 2)); T3077[4] = __v4 << __s | __c; __c = MASK(__v4 >> __r, __s != 0); val_t __v5 = MASK(T3076[CLAMP(5-__w, 0, 1)].values[0], (5 >= __w) & (5 < __w + 2)); T3077[5] = __v5 << __s | __c; __c = MASK(__v5 >> __r, __s != 0); val_t __v6 = MASK(T3076[CLAMP(6-__w, 0, 1)].values[0], (6 >= __w) & (6 < __w + 2)); T3077[6] = __v6 << __s | __c; __c = MASK(__v6 >> __r, __s != 0); val_t __v7 = MASK(T3076[CLAMP(7-__w, 0, 1)].values[0], (7 >= __w) & (7 < __w + 2)); T3077[7] = __v7 << __s | __c; __c = MASK(__v7 >> __r, __s != 0);}
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:4950:732: error: request for member 'values' in 'T3076[(((((4ull - __w) ^ 1ull) & ((val_t)(-(__w == 4ull)))) ^ 1ull) & ((val_t)(-((((4ull - __w) ^ 1ull) & ((val_t)(-(__w == 4ull)))) != 1ull))))]', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = 0x180L / 64; val_t __s = 0x180L % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T3076[CLAMP(0-__w, 0, 1)].values[0], (0 >= __w) & (0 < __w + 2)); T3077[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T3076[CLAMP(1-__w, 0, 1)].values[0], (1 >= __w) & (1 < __w + 2)); T3077[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0); val_t __v2 = MASK(T3076[CLAMP(2-__w, 0, 1)].values[0], (2 >= __w) & (2 < __w + 2)); T3077[2] = __v2 << __s | __c; __c = MASK(__v2 >> __r, __s != 0); val_t __v3 = MASK(T3076[CLAMP(3-__w, 0, 1)].values[0], (3 >= __w) & (3 < __w + 2)); T3077[3] = __v3 << __s | __c; __c = MASK(__v3 >> __r, __s != 0); val_t __v4 = MASK(T3076[CLAMP(4-__w, 0, 1)].values[0], (4 >= __w) & (4 < __w + 2)); T3077[4] = __v4 << __s | __c; __c = MASK(__v4 >> __r, __s != 0); val_t __v5 = MASK(T3076[CLAMP(5-__w, 0, 1)].values[0], (5 >= __w) & (5 < __w + 2)); T3077[5] = __v5 << __s | __c; __c = MASK(__v5 >> __r, __s != 0); val_t __v6 = MASK(T3076[CLAMP(6-__w, 0, 1)].values[0], (6 >= __w) & (6 < __w + 2)); T3077[6] = __v6 << __s | __c; __c = MASK(__v6 >> __r, __s != 0); val_t __v7 = MASK(T3076[CLAMP(7-__w, 0, 1)].values[0], (7 >= __w) & (7 < __w + 2)); T3077[7] = __v7 << __s | __c; __c = MASK(__v7 >> __r, __s != 0);}
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:4950:881: error: request for member 'values' in 'T3076[(((((5ull - __w) ^ 1ull) & ((val_t)(-(__w == 5ull)))) ^ 1ull) & ((val_t)(-((((5ull - __w) ^ 1ull) & ((val_t)(-(__w == 5ull)))) != 1ull))))]', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = 0x180L / 64; val_t __s = 0x180L % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T3076[CLAMP(0-__w, 0, 1)].values[0], (0 >= __w) & (0 < __w + 2)); T3077[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T3076[CLAMP(1-__w, 0, 1)].values[0], (1 >= __w) & (1 < __w + 2)); T3077[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0); val_t __v2 = MASK(T3076[CLAMP(2-__w, 0, 1)].values[0], (2 >= __w) & (2 < __w + 2)); T3077[2] = __v2 << __s | __c; __c = MASK(__v2 >> __r, __s != 0); val_t __v3 = MASK(T3076[CLAMP(3-__w, 0, 1)].values[0], (3 >= __w) & (3 < __w + 2)); T3077[3] = __v3 << __s | __c; __c = MASK(__v3 >> __r, __s != 0); val_t __v4 = MASK(T3076[CLAMP(4-__w, 0, 1)].values[0], (4 >= __w) & (4 < __w + 2)); T3077[4] = __v4 << __s | __c; __c = MASK(__v4 >> __r, __s != 0); val_t __v5 = MASK(T3076[CLAMP(5-__w, 0, 1)].values[0], (5 >= __w) & (5 < __w + 2)); T3077[5] = __v5 << __s | __c; __c = MASK(__v5 >> __r, __s != 0); val_t __v6 = MASK(T3076[CLAMP(6-__w, 0, 1)].values[0], (6 >= __w) & (6 < __w + 2)); T3077[6] = __v6 << __s | __c; __c = MASK(__v6 >> __r, __s != 0); val_t __v7 = MASK(T3076[CLAMP(7-__w, 0, 1)].values[0], (7 >= __w) & (7 < __w + 2)); T3077[7] = __v7 << __s | __c; __c = MASK(__v7 >> __r, __s != 0);}
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:4950:1030: error: request for member 'values' in 'T3076[(((((6ull - __w) ^ 1ull) & ((val_t)(-(__w == 6ull)))) ^ 1ull) & ((val_t)(-((((6ull - __w) ^ 1ull) & ((val_t)(-(__w == 6ull)))) != 1ull))))]', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = 0x180L / 64; val_t __s = 0x180L % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T3076[CLAMP(0-__w, 0, 1)].values[0], (0 >= __w) & (0 < __w + 2)); T3077[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T3076[CLAMP(1-__w, 0, 1)].values[0], (1 >= __w) & (1 < __w + 2)); T3077[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0); val_t __v2 = MASK(T3076[CLAMP(2-__w, 0, 1)].values[0], (2 >= __w) & (2 < __w + 2)); T3077[2] = __v2 << __s | __c; __c = MASK(__v2 >> __r, __s != 0); val_t __v3 = MASK(T3076[CLAMP(3-__w, 0, 1)].values[0], (3 >= __w) & (3 < __w + 2)); T3077[3] = __v3 << __s | __c; __c = MASK(__v3 >> __r, __s != 0); val_t __v4 = MASK(T3076[CLAMP(4-__w, 0, 1)].values[0], (4 >= __w) & (4 < __w + 2)); T3077[4] = __v4 << __s | __c; __c = MASK(__v4 >> __r, __s != 0); val_t __v5 = MASK(T3076[CLAMP(5-__w, 0, 1)].values[0], (5 >= __w) & (5 < __w + 2)); T3077[5] = __v5 << __s | __c; __c = MASK(__v5 >> __r, __s != 0); val_t __v6 = MASK(T3076[CLAMP(6-__w, 0, 1)].values[0], (6 >= __w) & (6 < __w + 2)); T3077[6] = __v6 << __s | __c; __c = MASK(__v6 >> __r, __s != 0); val_t __v7 = MASK(T3076[CLAMP(7-__w, 0, 1)].values[0], (7 >= __w) & (7 < __w + 2)); T3077[7] = __v7 << __s | __c; __c = MASK(__v7 >> __r, __s != 0);}
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:4950:1179: error: request for member 'values' in 'T3076[(((((7ull - __w) ^ 1ull) & ((val_t)(-(__w == 7ull)))) ^ 1ull) & ((val_t)(-((((7ull - __w) ^ 1ull) & ((val_t)(-(__w == 7ull)))) != 1ull))))]', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = 0x180L / 64; val_t __s = 0x180L % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T3076[CLAMP(0-__w, 0, 1)].values[0], (0 >= __w) & (0 < __w + 2)); T3077[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T3076[CLAMP(1-__w, 0, 1)].values[0], (1 >= __w) & (1 < __w + 2)); T3077[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0); val_t __v2 = MASK(T3076[CLAMP(2-__w, 0, 1)].values[0], (2 >= __w) & (2 < __w + 2)); T3077[2] = __v2 << __s | __c; __c = MASK(__v2 >> __r, __s != 0); val_t __v3 = MASK(T3076[CLAMP(3-__w, 0, 1)].values[0], (3 >= __w) & (3 < __w + 2)); T3077[3] = __v3 << __s | __c; __c = MASK(__v3 >> __r, __s != 0); val_t __v4 = MASK(T3076[CLAMP(4-__w, 0, 1)].values[0], (4 >= __w) & (4 < __w + 2)); T3077[4] = __v4 << __s | __c; __c = MASK(__v4 >> __r, __s != 0); val_t __v5 = MASK(T3076[CLAMP(5-__w, 0, 1)].values[0], (5 >= __w) & (5 < __w + 2)); T3077[5] = __v5 << __s | __c; __c = MASK(__v5 >> __r, __s != 0); val_t __v6 = MASK(T3076[CLAMP(6-__w, 0, 1)].values[0], (6 >= __w) & (6 < __w + 2)); T3077[6] = __v6 << __s | __c; __c = MASK(__v6 >> __r, __s != 0); val_t __v7 = MASK(T3076[CLAMP(7-__w, 0, 1)].values[0], (7 >= __w) & (7 < __w + 2)); T3077[7] = __v7 << __s | __c; __c = MASK(__v7 >> __r, __s != 0);}
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:8841:114: error: request for member 'values' in 'T4770', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = T4773 / 64; val_t __s = T4773 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T4770.values[0], (0 >= __w) & (0 < __w + 1)); T4774[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T4770.values[0], (1 >= __w) & (1 < __w + 1)); T4774[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                  ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:8841:243: error: request for member 'values' in 'T4770', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = T4773 / 64; val_t __s = T4773 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T4770.values[0], (0 >= __w) & (0 < __w + 1)); T4774[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T4770.values[0], (1 >= __w) & (1 < __w + 1)); T4774[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                                                                                                                                                   ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:8911:114: error: request for member 'values' in 'T4802', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = T4805 / 64; val_t __s = T4805 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T4802.values[0], (0 >= __w) & (0 < __w + 1)); T4806[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T4802.values[0], (1 >= __w) & (1 < __w + 1)); T4806[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                  ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:8911:243: error: request for member 'values' in 'T4802', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = T4805 / 64; val_t __s = T4805 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T4802.values[0], (0 >= __w) & (0 < __w + 1)); T4806[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T4802.values[0], (1 >= __w) & (1 < __w + 1)); T4806[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                                                                                                                                                   ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:9076:114: error: request for member 'values' in 'T4874', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = T4877 / 64; val_t __s = T4877 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T4874.values[0], (0 >= __w) & (0 < __w + 1)); T4878[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T4874.values[0], (1 >= __w) & (1 < __w + 1)); T4878[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                  ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:9076:243: error: request for member 'values' in 'T4874', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = T4877 / 64; val_t __s = T4877 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T4874.values[0], (0 >= __w) & (0 < __w + 1)); T4878[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T4874.values[0], (1 >= __w) & (1 < __w + 1)); T4878[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                                                                                                                                                   ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:9854:132: error: request for member 'values' in 'T5203[(((((- __w) ^ 1ull) & ((val_t)(-(__w == 0ull)))) ^ 1ull) & ((val_t)(-((((- __w) ^ 1ull) & ((val_t)(-(__w == 0ull)))) != 1ull))))]', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = 0x1L / 64; val_t __s = 0x1L % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T5203[CLAMP(0-__w, 0, 1)].values[0], (0 >= __w) & (0 < __w + 2)); T5204[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T5203[CLAMP(1-__w, 0, 1)].values[0], (1 >= __w) & (1 < __w + 2)); T5204[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                                    ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:9854:281: error: request for member 'values' in 'T5203[(((((1ull - __w) ^ 1ull) & ((val_t)(-(__w == 1ull)))) ^ 1ull) & ((val_t)(-((((1ull - __w) ^ 1ull) & ((val_t)(-(__w == 1ull)))) != 1ull))))]', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = 0x1L / 64; val_t __s = 0x1L % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T5203[CLAMP(0-__w, 0, 1)].values[0], (0 >= __w) & (0 < __w + 2)); T5204[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T5203[CLAMP(1-__w, 0, 1)].values[0], (1 >= __w) & (1 < __w + 2)); T5204[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                                                                                                                                                                                         ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:9868:132: error: request for member 'values' in 'T5208[(((((- __w) ^ 1ull) & ((val_t)(-(__w == 0ull)))) ^ 1ull) & ((val_t)(-((((- __w) ^ 1ull) & ((val_t)(-(__w == 0ull)))) != 1ull))))]', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = 0x1L / 64; val_t __s = 0x1L % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T5208[CLAMP(0-__w, 0, 1)].values[0], (0 >= __w) & (0 < __w + 2)); T5209[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T5208[CLAMP(1-__w, 0, 1)].values[0], (1 >= __w) & (1 < __w + 2)); T5209[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                                    ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:9868:281: error: request for member 'values' in 'T5208[(((((1ull - __w) ^ 1ull) & ((val_t)(-(__w == 1ull)))) ^ 1ull) & ((val_t)(-((((1ull - __w) ^ 1ull) & ((val_t)(-(__w == 1ull)))) != 1ull))))]', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = 0x1L / 64; val_t __s = 0x1L % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T5208[CLAMP(0-__w, 0, 1)].values[0], (0 >= __w) & (0 < __w + 2)); T5209[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T5208[CLAMP(1-__w, 0, 1)].values[0], (1 >= __w) & (1 < __w + 2)); T5209[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                                                                                                                                                                                         ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:10311:114: error: request for member 'values' in 'T5394', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = 0x36L / 64; val_t __s = 0x36L % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T5394.values[0], (0 >= __w) & (0 < __w + 1)); T5395[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T5394.values[0], (1 >= __w) & (1 < __w + 1)); T5395[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                  ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:10311:243: error: request for member 'values' in 'T5394', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = 0x36L / 64; val_t __s = 0x36L % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T5394.values[0], (0 >= __w) & (0 < __w + 1)); T5395[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T5394.values[0], (1 >= __w) & (1 < __w + 1)); T5395[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                                                                                                                                                   ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:10317:114: error: request for member 'values' in 'T5396', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = 0x56L / 64; val_t __s = 0x56L % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T5396.values[0], (0 >= __w) & (0 < __w + 1)); T5397[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T5396.values[0], (1 >= __w) & (1 < __w + 1)); T5397[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                  ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:10317:243: error: request for member 'values' in 'T5396', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = 0x56L / 64; val_t __s = 0x56L % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T5396.values[0], (0 >= __w) & (0 < __w + 1)); T5397[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T5396.values[0], (1 >= __w) & (1 < __w + 1)); T5397[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                                                                                                                                                   ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:10349:134: error: request for member 'values' in 'T5410[(((((- __w) ^ 1ull) & ((val_t)(-(__w == 0ull)))) ^ 1ull) & ((val_t)(-((((- __w) ^ 1ull) & ((val_t)(-(__w == 0ull)))) != 1ull))))]', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = 0x16L / 64; val_t __s = 0x16L % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T5410[CLAMP(0-__w, 0, 1)].values[0], (0 >= __w) & (0 < __w + 2)); T5411[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T5410[CLAMP(1-__w, 0, 1)].values[0], (1 >= __w) & (1 < __w + 2)); T5411[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                                      ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:10349:283: error: request for member 'values' in 'T5410[(((((1ull - __w) ^ 1ull) & ((val_t)(-(__w == 1ull)))) ^ 1ull) & ((val_t)(-((((1ull - __w) ^ 1ull) & ((val_t)(-(__w == 1ull)))) != 1ull))))]', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = 0x16L / 64; val_t __s = 0x16L % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T5410[CLAMP(0-__w, 0, 1)].values[0], (0 >= __w) & (0 < __w + 2)); T5411[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T5410[CLAMP(1-__w, 0, 1)].values[0], (1 >= __w) & (1 < __w + 2)); T5411[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                                                                                                                                                                                           ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:11023:114: error: request for member 'values' in 'T5664', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = 0x40L / 64; val_t __s = 0x40L % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T5664.values[0], (0 >= __w) & (0 < __w + 1)); Top_Tile_core_FPU_dfma__zero[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T5664.values[0], (1 >= __w) & (1 < __w + 1)); Top_Tile_core_FPU_dfma__zero[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                  ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:11023:266: error: request for member 'values' in 'T5664', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = 0x40L / 64; val_t __s = 0x40L % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T5664.values[0], (0 >= __w) & (0 < __w + 1)); Top_Tile_core_FPU_dfma__zero[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T5664.values[0], (1 >= __w) & (1 < __w + 1)); Top_Tile_core_FPU_dfma__zero[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                                                                                                                                                                          ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:13062:114: error: request for member 'values' in 'T6461', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = T6458 / 64; val_t __s = T6458 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T6461.values[0], (0 >= __w) & (0 < __w + 1)); T6462[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T6461.values[0], (1 >= __w) & (1 < __w + 1)); T6462[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                  ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:13062:243: error: request for member 'values' in 'T6461', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = T6458 / 64; val_t __s = T6458 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T6461.values[0], (0 >= __w) & (0 < __w + 1)); T6462[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T6461.values[0], (1 >= __w) & (1 < __w + 1)); T6462[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                                                                                                                                                   ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:14707:114: error: request for member 'values' in 'T7191', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = T7194 / 64; val_t __s = T7194 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T7191.values[0], (0 >= __w) & (0 < __w + 1)); T7195[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T7191.values[0], (1 >= __w) & (1 < __w + 1)); T7195[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                  ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:14707:243: error: request for member 'values' in 'T7191', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = T7194 / 64; val_t __s = T7194 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T7191.values[0], (0 >= __w) & (0 < __w + 1)); T7195[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T7191.values[0], (1 >= __w) & (1 < __w + 1)); T7195[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                                                                                                                                                   ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:16006:114: error: request for member 'values' in 'T7742', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = T7646 / 64; val_t __s = T7646 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T7742.values[0], (0 >= __w) & (0 < __w + 1)); T7743[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T7742.values[0], (1 >= __w) & (1 < __w + 1)); T7743[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                  ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
generated-src/Top.DefaultCPPConfig-3.cpp:16006:243: error: request for member 'values' in 'T7742', which is of non-class type 'val_t {aka long long unsigned int}'
   { val_t __c = 0; val_t __w = T7646 / 64; val_t __s = T7646 % 64; val_t __r = 64 - __s; val_t __v0 = MASK(T7742.values[0], (0 >= __w) & (0 < __w + 1)); T7743[0] = __v0 << __s | __c; __c = MASK(__v0 >> __r, __s != 0); val_t __v1 = MASK(T7742.values[0], (1 >= __w) & (1 < __w + 1)); T7743[1] = __v1 << __s | __c; __c = MASK(__v1 >> __r, __s != 0);}
                                                                                                                                                                                                                                                   ^
generated-src/emulator_mod.h:93:22: note: in definition of macro 'MASK'
 #define MASK(v, c) ((v) & -(val_t)(c))
                      ^
make[1]: *** [generated-src/Top.DefaultCPPConfig-3.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make: *** [Top.DefaultCPPConfig.o] Error 2

Compilation exited abnormally with code 2 at Tue Sep 16 15:06:55
```
