### PR TITLE
Update ShiftRegister to support a parameterized delay of 0 - #249.

### DIFF
--- a/src/main/scala/ChiselUtil.scala
+++ b/src/main/scala/ChiselUtil.scala
@@ -132,8 +132,14 @@ object ShiftRegister
 {
   def apply[T <: Data](in: T, n: Int, en: Bool = Bool(true)): T =
   {
-    if (n == 1) RegEnable(in, en)
-    else RegNext(apply(in, n-1, en))
+    // The order of tests reflects the expected use cases.
+    if (n == 1) {
+      RegEnable(in, en)
+    } else if (n != 0) {
+      RegNext(apply(in, n-1, en))
+    } else {
+      in
+    }
   }
 }
 


### PR DESCRIPTION
Update testShiftRegister to test all the significant delay parameters (test coverage) and actually run the tester instead of just compiling the code.
