### PR TITLE
Cosmetic/scalastyle fixes - no functional changes.

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -9,7 +9,7 @@
  <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
   <parameters>
    <parameter name="header"><![CDATA[/*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:
@@ -81,9 +81,9 @@
  </check>
  <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="true"></check>
- <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
+ <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="false"></check>
+ <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="false"></check>
+ <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="false"></check>
  <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
  <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="true"></check>

--- a/src/main/scala/AdvTester.scala
+++ b/src/main/scala/AdvTester.scala
@@ -1,4 +1,34 @@
 /*
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
+ California (Regents). All Rights Reserved.  Redistribution and use in
+ source and binary forms, with or without modification, are permitted
+ provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer in the documentation and/or other materials
+      provided with the distribution.
+    * Neither the name of the Regents nor the names of its contributors
+      may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+ IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
+ ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION
+ TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ MODIFICATIONS.
+*/
+
+/*
   Written by Stephen Twigg, Eric Love
   Version 0.9
 */
@@ -27,14 +57,14 @@ class AdvTester[+T <: Module](val dut: T) extends Tester[T](dut, false) {
 
   override def poke(port: Bits, target: BigInt) = require(false, "poke hidden for AdvTester, use wire_poke or reg_poke")
   override def poke(port: Aggregate, target: Array[BigInt]) = require(false, "poke hidden for AdvTester, use wire_poke or reg_poke")
-  
+
   val registered_bits_updates = new scala.collection.mutable.HashMap[Bits,BigInt]()
   val registered_aggr_updates = new scala.collection.mutable.HashMap[Aggregate,Array[BigInt]]()
-  
+
   def do_registered_updates() = {
     registered_bits_updates.foreach( kv => wire_poke(kv._1,kv._2) )
     registered_aggr_updates.foreach( kv => wire_poke(kv._1,kv._2) )
-    
+
     registered_bits_updates.clear()
     registered_aggr_updates.clear()
   }
@@ -45,7 +75,7 @@ class AdvTester[+T <: Module](val dut: T) extends Tester[T](dut, false) {
   // Convenience functions
   def Boolean2Int(i: Boolean): Int = (if(i) 1 else 0) // TODO: Investigate name and inclusion as a Chisel Tester auto-convert
 
-  // This function replaces step in the advanced tester and makes sure all tester features are clocked in the appropriate order 
+  // This function replaces step in the advanced tester and makes sure all tester features are clocked in the appropriate order
   def takestep(work: => Unit = {}): Unit = {
     cycles += 1
     step(1)

--- a/src/main/scala/Assert.scala
+++ b/src/main/scala/Assert.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/Backend.scala
+++ b/src/main/scala/Backend.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:
@@ -63,7 +63,7 @@ trait FileSystemUtilities {
 abstract class Backend extends FileSystemUtilities{
   /* Set of keywords which cannot be used as node and component names. */
   val keywords: HashSet[String];
-  val nameSpace = HashSet[String]() 
+  val nameSpace = HashSet[String]()
   /* Set of Ops that this backend doesn't natively support and thus must be
      lowered to simpler Ops. */
   val needsLowering = Set[String]()

--- a/src/main/scala/Binding.scala
+++ b/src/main/scala/Binding.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/Bits.scala
+++ b/src/main/scala/Bits.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:
@@ -80,7 +80,7 @@ abstract class Bits extends Data with proc {
   // internal, non user exposed connectors
   private var assigned = false
   private def checkAssign(src: Node) = {
-    if (this.dir == INPUT && this.component == Module.current && 
+    if (this.dir == INPUT && this.component == Module.current &&
         this.component.wires.unzip._2.contains(this)) {
       ChiselError.error({"assigning to your own input port " + this + " RHS: " + src});
     }

--- a/src/main/scala/Bool.scala
+++ b/src/main/scala/Bool.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/Bundle.scala
+++ b/src/main/scala/Bundle.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/Cat.scala
+++ b/src/main/scala/Cat.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/ChiselError.scala
+++ b/src/main/scala/ChiselError.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/ChiselUtil.scala
+++ b/src/main/scala/ChiselUtil.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/Complex.scala
+++ b/src/main/scala/Complex.scala
@@ -1,8 +1,38 @@
+/*
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
+ California (Regents). All Rights Reserved.  Redistribution and use in
+ source and binary forms, with or without modification, are permitted
+ provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer in the documentation and/or other materials
+      provided with the distribution.
+    * Neither the name of the Regents nor the names of its contributors
+      may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+ IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
+ ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION
+ TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ MODIFICATIONS.
+*/
+
 package Chisel
 
 object Complex {
   var use_four_mults = false
- 
+
   def apply[T<:Data with Num[T]](real: T, imag: T) = new Complex(real, imag)
 }
 
@@ -45,12 +75,12 @@ class Complex[T<:Data with Num[T]](val real: T, val imag: T) extends Bundle {
   {
     new Complex(real + r.real, imag + r.imag)
   }
-  def - (r: Complex[T]): Complex[T] = 
+  def - (r: Complex[T]): Complex[T] =
   {
     new Complex(real - r.real, imag - r.imag)
   }
 
-  def unary_-(): Complex[T] = 
+  def unary_-(): Complex[T] =
   {
     new Complex(-real, -imag)
   }

--- a/src/main/scala/Cpp.scala
+++ b/src/main/scala/Cpp.scala
@@ -372,13 +372,13 @@ class CppBackend extends Backend {
               res += s"${emitWordRef(o, i)} = __v${i} >> __s | __c"
               res += s"__c = MASK(__v${i} << __r, __s != 0)"
               if (arith) {
-	        val gotWidth = o.needWidth()
+                val gotWidth = o.needWidth()
                 res += s"${emitWordRef(o, i)} |= MASK(__msb << ((${gotWidth-1}-${emitLoWordRef(o.inputs(1))}) % ${bpw}), ${(i + 1) * bpw} > ${gotWidth-1} - ${emitLoWordRef(o.inputs(1))})"
                 res += s"${emitWordRef(o, i)} |= MASK(__msb, ${i*bpw} >= ${gotWidth-1} - ${emitLoWordRef(o.inputs(1))})"
               }
             }
             if (arith) {
-	      val gotWidth = o.needWidth()
+              val gotWidth = o.needWidth()
               res += emitLoWordRef(o) + " |= MASK(__msb << ((" + (gotWidth-1) + "-" + emitLoWordRef(o.inputs(1)) + ") % " + bpw + "), " + bpw + " > " + (gotWidth-1) + "-" + emitLoWordRef(o.inputs(1)) + ")"
             }
             block(res) + (if (arith) trunc(o) else "")
@@ -1414,7 +1414,7 @@ class CppBackend extends Backend {
           for (m <- Driver.orderedNodes) {
             addClkDefs(m, code)
           }
-          // For the non-patitioned case, we're going to merge the clock_hi init and def code into a single function.
+          // For the non-partitioned case, we're going to merge the clock_hi init and def code into a single function.
           // Add the closing brace to the def string.
           for (clk <- code.keys) {
             code(clk)._1.append("}\n")
@@ -1603,17 +1603,17 @@ class CppBackend extends Backend {
     out_cpps.clear()
 
     def copyToTarget(filename: String) = {
-	  val resourceStream = getClass().getResourceAsStream("/" + filename)
-	  if( resourceStream != null ) {
-	    val classFile = createOutputFile(filename)
-	    while(resourceStream.available > 0) {
-	      classFile.write(resourceStream.read())
-	    }
-	    classFile.close()
-	    resourceStream.close()
-	  } else {
-		println(s"WARNING: Unable to copy '$filename'" )
-	  }
+      val resourceStream = getClass().getResourceAsStream("/" + filename)
+      if( resourceStream != null ) {
+        val classFile = createOutputFile(filename)
+        while(resourceStream.available > 0) {
+          classFile.write(resourceStream.read())
+        }
+        classFile.close()
+        resourceStream.close()
+      } else {
+        println(s"WARNING: Unable to copy '$filename'" )
+      }
     }
     /* Copy the emulator headers into the targetDirectory. */
     copyToTarget("emulator_mod.h")

--- a/src/main/scala/Data.scala
+++ b/src/main/scala/Data.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/Dot.scala
+++ b/src/main/scala/Dot.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/Driver.scala
+++ b/src/main/scala/Driver.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:
@@ -55,17 +55,17 @@ object Driver extends FileSystemUtilities{
   }
 
   private def executeUnwrapped[T <: Module](gen: () => T): T = {
-    if (!chiselConfigMode.isEmpty && !chiselConfigClassName.isEmpty) { 
+    if (!chiselConfigMode.isEmpty && !chiselConfigClassName.isEmpty) {
       val name = appendString(chiselProjectName,chiselConfigClassName)
       val config = try {
         Class.forName(name).newInstance.asInstanceOf[ChiselConfig]
       } catch {
-        case e: java.lang.ClassNotFoundException => 
-          throwException("Could not find the ChiselConfig subclass you asked for (\"" + 
+        case e: java.lang.ClassNotFoundException =>
+          throwException("Could not find the ChiselConfig subclass you asked for (\"" +
                           name + "\"), did you misspell it?", e)
       }
       val world = if(chiselConfigMode.get == "collect") {
-        new Collector(config.topDefinitions,config.knobValues) 
+        new Collector(config.topDefinitions,config.knobValues)
       } else { new Instance(config.topDefinitions,config.knobValues) }
       val p = Parameters.root(world)
       config.topConstraints.foreach(c => p.constrain(c))
@@ -79,7 +79,7 @@ object Driver extends FileSystemUtilities{
         w.close
       }
       c
-    } 
+    }
     else {
       execute(() => Module(gen()))
     }

--- a/src/main/scala/Enum.scala
+++ b/src/main/scala/Enum.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/Extract.scala
+++ b/src/main/scala/Extract.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/FP.scala
+++ b/src/main/scala/FP.scala
@@ -39,7 +39,7 @@ import java.lang.Float.floatToIntBits
 object Flo {
   def apply(x: Float): Flo = Lit(floatToIntBits(x), 32){ Flo() }
   def apply(x: Double): Flo = Flo(x.toFloat);
-  
+
   def apply(dir: IODirection = null): Flo = {
     val res = new Flo();
     res.dir = dir;
@@ -82,7 +82,7 @@ class Flo extends Bits with Num[Flo] {
   def <  (b: Flo): Bool = newLogicalOp(b, "f<")
   def <= (b: Flo): Bool = newLogicalOp(b, "f<=")
   def >= (b: Flo): Bool = newLogicalOp(b, "f>=")
-  def pow (b: Flo): Flo = newBinaryOp(b, "fpow") 
+  def pow (b: Flo): Flo = newBinaryOp(b, "fpow")
   def sin: Flo = newUnaryOp("fsin")
   def cos: Flo = newUnaryOp("fcos")
   def tan: Flo = newUnaryOp("ftan")

--- a/src/main/scala/FPGA.scala
+++ b/src/main/scala/FPGA.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/FameBackend.scala
+++ b/src/main/scala/FameBackend.scala
@@ -67,25 +67,25 @@ class FameQueue[T <: Data] (val entries: Int)(data: => T) extends Module
     val deq = new FameDecoupledIO(data)
     val enq = new FameDecoupledIO(data).flip()
   }
-  
+
   val target_queue = Module(new Queue(data, entries))
   val tracker = Module(new FameQueueTracker(entries, entries))
-  
+
   target_queue.io.enq.valid := io.enq.host_valid && io.enq.target.valid
   target_queue.io.enq.bits := io.enq.target.bits
   io.enq.target.ready := target_queue.io.enq.ready
-  
+
   io.deq.target.valid := tracker.io.entry_avail && target_queue.io.deq.valid
   io.deq.target.bits := target_queue.io.deq.bits
   target_queue.io.deq.ready := io.deq.host_ready && io.deq.target.ready && tracker.io.entry_avail
-  
+
   tracker.io.tgt_queue_count := target_queue.io.count
   tracker.io.produce := io.enq.host_valid && io.enq.host_ready
   tracker.io.consume := io.deq.host_valid && io.deq.host_ready
   tracker.io.tgt_enq := target_queue.io.enq.valid && target_queue.io.enq.ready
   tracker.io.tgt_deq := io.deq.target.valid && target_queue.io.deq.ready
 
-  io.enq.host_ready := !tracker.io.full && target_queue.io.enq.ready 
+  io.enq.host_ready := !tracker.io.full && target_queue.io.enq.ready
   io.deq.host_valid := !tracker.io.empty
   
 }

--- a/src/main/scala/Fill.scala
+++ b/src/main/scala/Fill.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/Flo.scala
+++ b/src/main/scala/Flo.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:
@@ -111,7 +111,7 @@ class FloBackend extends Backend {
       case o: Op =>
         emitDec(o) +
         (if (o.inputs.length == 1) {
-	  val gotWidth = node.inputs(0).needWidth()
+          val gotWidth = node.inputs(0).needWidth()
           o.op match {
             case "~" => "not'" + gotWidth + " " + emitRef(node.inputs(0))
             case "^" => "xorr'" + gotWidth + " " + emitRef(node.inputs(0))

--- a/src/main/scala/IO.scala
+++ b/src/main/scala/IO.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/ImplicitConversions.scala
+++ b/src/main/scala/ImplicitConversions.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/Insert.scala
+++ b/src/main/scala/Insert.scala
@@ -1,3 +1,33 @@
+/*
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
+ California (Regents). All Rights Reserved.  Redistribution and use in
+ source and binary forms, with or without modification, are permitted
+ provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer in the documentation and/or other materials
+      provided with the distribution.
+    * Neither the name of the Regents nor the names of its contributors
+      may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+ IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
+ ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION
+ TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ MODIFICATIONS.
+*/
+
 package Chisel
 
 class Insert(tgt: Bits, bit: UInt, length: Int) extends proc {

--- a/src/main/scala/Lit.scala
+++ b/src/main/scala/Lit.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/Log2.scala
+++ b/src/main/scala/Log2.scala
@@ -1,3 +1,33 @@
+/*
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
+ California (Regents). All Rights Reserved.  Redistribution and use in
+ source and binary forms, with or without modification, are permitted
+ provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer in the documentation and/or other materials
+      provided with the distribution.
+    * Neither the name of the Regents nor the names of its contributors
+      may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+ IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
+ ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION
+ TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ MODIFICATIONS.
+*/
+
 package Chisel
 
 object Log2 {

--- a/src/main/scala/Lookup.scala
+++ b/src/main/scala/Lookup.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/Mem.scala
+++ b/src/main/scala/Mem.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/Module.scala
+++ b/src/main/scala/Module.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:
@@ -120,18 +120,18 @@ object Module {
    ( + ) clock parameter
          ( + ) by default, use parent's clock
          ( + ) sets the default clock domain for all Delay nodes within scope
-         ( + ) overriden if Delay specifies its own clock
+         ( + ) overridden if Delay specifies its own clock
    ( + ) reset parameter
          ( + ) sets the default reset signal
-         ( + ) overriden if Delay specifies its own clock w/ reset != implicitReset
+         ( + ) overridden if Delay specifies its own clock w/ reset != implicitReset
 */
 abstract class Module(var clock: Clock = null, private[Chisel] var _reset: Bool = null) {
   /** A backend(Backend.scala) might generate multiple module source code
-    from one Module, based on the parameters to instanciate the component
+    from one Module, based on the parameters to instantiate the component
     instance. Since we do not want to blindly generate one module per instance
     the backend will keep a cache of each module's implementation source code
     and discard textual duplicates. By walking the nodes from level zero
-    (leafs) to level N (root), we are guarenteed to generate all
+    (leafs) to level N (root), we are guaranteed to generate all
     Module/modules source text before their first instantiation. */
   var level = 0;
   var traversal = 0;

--- a/src/main/scala/Mux.scala
+++ b/src/main/scala/Mux.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/Op.scala
+++ b/src/main/scala/Op.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/Parameters.scala
+++ b/src/main/scala/Parameters.scala
@@ -3,10 +3,10 @@
  Regents of the University of California, through Lawrence Berkeley National
  Laboratory (subject to receipt of any required approvals from the U.S. Dept.
    of Energy).  All rights reserved.
- 
+
  If you have questions about your rights to use or distribute this software,
  please contact Berkeley Lab's Technology Transfer Department at  TTD@lbl.gov.
- 
+
  NOTICE.  This software is owned by the U.S. Department of Energy.  As such,
  the U.S. Government has been granted for itself and others acting on its
  behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software
@@ -18,22 +18,22 @@
  worldwide license in the Software to reproduce, prepare derivative works,
  distribute copies to the public, perform publicly and display publicly, and to
  permit others to do so.
- 
+
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions are met:
- 
+
  (1) Redistributions of source code must retain the above copyright notice,
  this list of conditions and the following disclaimer.
- 
+
  (2) Redistributions in binary form must reproduce the above copyright notice,
  this list of conditions and the following disclaimer in the documentation
  and/or other materials provided with the distribution.
- 
+
  (3) Neither the name of the University of California, Lawrence Berkeley
  National Laboratory, U.S. Dept. of Energy nor the names of its contributors
  may be used to endorse or promote products derived from this software without
  specific prior written permission.
- 
+
  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -44,7 +44,7 @@
  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
+
  You are under no obligation whatsoever to provide any bug fixes, patches, or
  upgrades to the features, functionality or performance of the source code
  ("Enhancements") to anyone; however, if you choose to make your Enhancements
@@ -54,7 +54,7 @@
  royalty-free perpetual license to install, use, modify, prepare derivative
  works, incorporate into other computer software, distribute, and sublicense
  such enhancements or derivative works thereof, in binary and source code form.
- 
+
  Authors: J. Bachan, A. Izraelevitz, H. Cook
 */
 

--- a/src/main/scala/Params.scala
+++ b/src/main/scala/Params.scala
@@ -67,7 +67,7 @@ case class ValueParam(pname:String, init: Any) extends Param[Any] {
   val min = init.toString.toInt
 }
 
-case class RangeParam(pname:String, init: Int, min: Int, max: Int) extends Param[Int] 
+case class RangeParam(pname:String, init: Int, min: Int, max: Int) extends Param[Int]
 
 case class LessParam(pname:String, init: Int, min: Int, par: Param[Any]) extends Param[Int] {
   val max = par.max

--- a/src/main/scala/ROM.scala
+++ b/src/main/scala/ROM.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/Reg.scala
+++ b/src/main/scala/Reg.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:
@@ -49,18 +49,18 @@ object Reg {
 /*
     The (implicit d: DummyImplicit) is to avoid the conflict with the
     above regWidth(w: => Width) method:
-	  double definition:
-	  method regWidth:(r: => Chisel.Node)(=> Chisel.Node) => Chisel.Width and
-	  method regWidth:(w: => Chisel.Width)(=> Chisel.Node) => Chisel.Width at line 49
-	  have same type after erasure: (r: Function0)Function1
-	  def regWidth(r: => Node) = {
+    double definition:
+    method regWidth:(r: => Chisel.Node)(=> Chisel.Node) => Chisel.Width and
+    method regWidth:(w: => Chisel.Width)(=> Chisel.Node) => Chisel.Width at line 49
+    have same type after erasure: (r: Function0)Function1
+    def regWidth(r: => Node) = {
   */
 
   def regWidth(w: => Width)(implicit d: DummyImplicit) =
     if (! w.isKnown) {
       regMaxWidth _ ;
     } else {
-      fixWidth(w.needWidth())	 // TODO 0WW
+      fixWidth(w.needWidth())  // TODO 0WW
     }
 
   /** Rule: if r is using an inferred width, then don't enforce a width. If it is using a user inferred

--- a/src/main/scala/SCWrapper.scala
+++ b/src/main/scala/SCWrapper.scala
@@ -1,3 +1,33 @@
+/*
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
+ California (Regents). All Rights Reserved.  Redistribution and use in
+ source and binary forms, with or without modification, are permitted
+ provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer in the documentation and/or other materials
+      provided with the distribution.
+    * Neither the name of the Regents nor the names of its contributors
+      may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+ IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
+ ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION
+ TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ MODIFICATIONS.
+*/
+
 package Chisel
 
 import scala.collection.mutable.ArrayBuffer
@@ -23,7 +53,7 @@ object SCWrapper {
     write_file("generated/generated.cpp", filled)
 
     //Debug
-    System.out.println(filled) //DEBUG      
+    System.out.println(filled) //DEBUG
   }
 
   def example_component_def(): ComponentDef = {
@@ -41,9 +71,9 @@ object SCWrapper {
   }
 
   def genwrapper(c: ComponentDef, filename:  String) {
-    //Read in template      
+    //Read in template
     val template = read_resource("template.txt")
-  
+
     //Generate replacements
     val replacements = generate_replacements(c)
 
@@ -56,7 +86,7 @@ object SCWrapper {
   }
 
   def genwrapper(c: ComponentDef, filewriter: java.io.FileWriter){
-    //Read in template      
+    //Read in template
     val template = read_resource("template.txt")
 
     //Generate replacements

--- a/src/main/scala/SInt.scala
+++ b/src/main/scala/SInt.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/Tester.scala
+++ b/src/main/scala/Tester.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:
@@ -57,7 +57,7 @@ class ManualTester[+T <: Module]
 
   /**
    * Waits until the emulator streams are ready. This is a dirty hack related
-   * to the way Process works. TODO: FIXME. 
+   * to the way Process works. TODO: FIXME.
    */
   def waitForStreams() = {
     var waited = 0

--- a/src/main/scala/UInt.scala
+++ b/src/main/scala/UInt.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/Vcd.scala
+++ b/src/main/scala/Vcd.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:
@@ -64,7 +64,7 @@ class VcdBackend(top: Module) extends Backend {
     "K" + index + ":\n"
 
   private def emitDef1(node: Node, offset: Int, index: Int) =
-    "  if (" + emitRef(node) + ".get(0x" + offset.toHexString +") != " + emitRef(node) + 
+    "  if (" + emitRef(node) + ".get(0x" + offset.toHexString +") != " + emitRef(node) +
     "__prev.get(0x" + offset.toHexString + "))\n" +
     "    goto L" + index + ";\n" +
     "K" + index + ":\n"
@@ -77,7 +77,7 @@ class VcdBackend(top: Module) extends Backend {
 
   private def emitDef2(node: Node, offset: Int, index: Int) =
     "L" + index + ":\n" +
-    "  " + emitRef(node) + "__prev.get(0x" + offset.toHexString + ") = " + 
+    "  " + emitRef(node) + "__prev.get(0x" + offset.toHexString + ") = " +
     emitRef(node) + ".get(0x" + offset.toHexString + ");\n" +
     emitDefUnconditional(node, offset, index) +
     "  goto K" + index + ";\n"

--- a/src/main/scala/Vec.scala
+++ b/src/main/scala/Vec.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/Verilog.scala
+++ b/src/main/scala/Verilog.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/hcl.scala
+++ b/src/main/scala/hcl.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/main/scala/when.scala
+++ b/src/main/scala/when.scala
@@ -1,3 +1,33 @@
+/*
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
+ California (Regents). All Rights Reserved.  Redistribution and use in
+ source and binary forms, with or without modification, are permitted
+ provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer in the documentation and/or other materials
+      provided with the distribution.
+    * Neither the name of the Regents nor the names of its contributors
+      may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+ IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
+ ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION
+ TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ MODIFICATIONS.
+*/
+
 package Chisel
 
 object when {

--- a/src/test/scala/AddFilter.scala
+++ b/src/test/scala/AddFilter.scala
@@ -48,14 +48,14 @@ class MyCounter extends Module {
    }
 
    val c = Reg(UInt(0, width = 8))
-   
+
    val out = UInt(width = 8)
    out := c
    io.out.bits := out(7,4)
    io.out.valid := out(3,0) === UInt(0)
    when(io.out.ready){
       c := c + UInt(1)
-   }   
+   }
 }
 
 
@@ -79,8 +79,8 @@ object AddFilter {
     for(i <- 0 until args.length){
        if(args(i).equals("--design")) {
           design = args(i + 1)
-	  // Remove the arguments that only we understand
-	  argsBuild.remove(i, 2)
+    // Remove the arguments that only we understand
+    argsBuild.remove(i, 2)
        }
     }
     println(design)

--- a/src/test/scala/BitsTest.scala
+++ b/src/test/scala/BitsTest.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/test/scala/ConnectTest.scala
+++ b/src/test/scala/ConnectTest.scala
@@ -1,3 +1,33 @@
+/*
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
+ California (Regents). All Rights Reserved.  Redistribution and use in
+ source and binary forms, with or without modification, are permitted
+ provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer in the documentation and/or other materials
+      provided with the distribution.
+    * Neither the name of the Regents nor the names of its contributors
+      may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+ IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
+ ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION
+ TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ MODIFICATIONS.
+*/
+
 import scala.collection.mutable.ArrayBuffer
 import org.junit.Assert._
 import org.junit.Test
@@ -46,14 +76,14 @@ class ConnectSuite extends TestSuite {
         expect(m.io.out.valid, int(true))
         expect(m.io.in.ready,  int(true))
         expect(m.io.out.bits,  i+1)
-      } 
+      }
     }
     launchCppTester((m: UsesShimParent) => new ShimConnectionsTests(m))
   }
 
   // Test different forms of reset propagation
   @Test def testResetConnections() {
-    class UsesReset(resetSignal: Bool = null) extends Module(_reset = resetSignal) { 
+    class UsesReset(resetSignal: Bool = null) extends Module(_reset = resetSignal) {
       val io = new BoolIO
       val q = Module(new Queue(Bool(), 1))
       q.io.enq.valid := Bool(true)

--- a/src/test/scala/DataTest.scala
+++ b/src/test/scala/DataTest.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/test/scala/DelayTest.scala
+++ b/src/test/scala/DelayTest.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/test/scala/DotBackendTest.scala
+++ b/src/test/scala/DotBackendTest.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/test/scala/MultiClockTest.scala
+++ b/src/test/scala/MultiClockTest.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/test/scala/NameTest.scala
+++ b/src/test/scala/NameTest.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/test/scala/StdlibTest.scala
+++ b/src/test/scala/StdlibTest.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:

--- a/src/test/scala/TestSuite.scala
+++ b/src/test/scala/TestSuite.scala
@@ -1,3 +1,33 @@
+/*
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
+ California (Regents). All Rights Reserved.  Redistribution and use in
+ source and binary forms, with or without modification, are permitted
+ provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer in the documentation and/or other materials
+      provided with the distribution.
+    * Neither the name of the Regents nor the names of its contributors
+      may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+ IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
+ ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION
+ TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ MODIFICATIONS.
+*/
+
 import org.scalatest.junit.AssertionsForJUnit
 import org.junit.Before
 import java.io.File

--- a/src/test/scala/VerifTest.scala
+++ b/src/test/scala/VerifTest.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:
@@ -85,7 +85,7 @@ class VerifSuite extends TestSuite {
       io.z := Cat(io.x, io.y)
     }
     /** XXX Can't run CppBackend back-to-back in the same process
-      because the emulator resource is closed. 
+      because the emulator resource is closed.
     chiselMain(Array[String]("--backend", "c",
       "--targetDir", dir.getPath.toString()),
       () => Module(new CppPrintfComp()))

--- a/src/test/scala/WhenTest.scala
+++ b/src/test/scala/WhenTest.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011, 2012, 2013 The Regents of the University of
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:
@@ -48,7 +48,7 @@ class WhenSuite extends TestSuite {
     }
 
     class WhenModuleTests(m: WhenModule) extends Tester(m) {
-      List(false,true,false,true,false,false,false,true).zipWithIndex.map { 
+      List(false,true,false,true,false,false,false,true).zipWithIndex.map {
         case (en, i) =>
           poke(m.io.en, int(en))
           poke(m.io.in, i)
@@ -75,14 +75,14 @@ class WhenSuite extends TestSuite {
 
     class EmbedWhenModuleTests(m: EmbedWhenModule) extends Tester(m) {
       List(false, true, false, true,  true, false, true,  true).zip(
-      List(false, true, true,  false, true, true,  false, true)).zipWithIndex.map { 
+      List(false, true, true,  false, true, true,  false, true)).zipWithIndex.map {
         case ((en0, en1), i) =>
           poke(m.io.en0, int(en0))
           poke(m.io.en1, int(en1))
           poke(m.io.in,  i)
           step(1)
           expect(m.io.out, if(en0 && en1) i else 0)
-      } 
+      }
     }
 
     launchCppTester((m: EmbedWhenModule) => new EmbedWhenModuleTests(m))

--- a/src/test/scala/ZeroWidthTest.scala
+++ b/src/test/scala/ZeroWidthTest.scala
@@ -49,7 +49,7 @@ object ZeroWidthTest{
     val W0Wenable = if (W0Wparameter == null) enableW0W else true
     org.junit.Assume.assumeTrue(W0Wenable)
   }
-  
+
 }
 /** This testsuite checks operations using zero-width wires.
 */


### PR DESCRIPTION
Update copyright date.
Add missing copyright header.
Remove trailing whitespace.
Convert tabs to spaces.
Correct spelling in comments.
Disable scalastyle "return", "null", & "clone" checkers.
