### PR TITLE
Change Node.line from val to def to respect --lineNumbers option

### DIFF
--- a/src/main/scala/Node.scala
+++ b/src/main/scala/Node.scala
@@ -149,10 +149,10 @@ abstract class Node extends nameable {
   val consumers = LinkedHashSet[Node]() // nodes that consume one of my outputs
 
   var nameHolder: nameable = null;
-  val line: StackTraceElement =
+  private val createTrace = new Throwable().getStackTrace
+  def line: StackTraceElement =
     if (Driver.getLineNumbers) {
-      val trace = new Throwable().getStackTrace
-      findFirstUserLine(trace) getOrElse trace(0)
+      findFirstUserLine(createTrace) getOrElse createTrace(0)
     } else null
   var prune = false
   var driveRand = false


### PR DESCRIPTION
The "line" function returns the line number that a Node was created on
using the stack trace. However, it checks the getLineNumbers option to
decide whether or not to actually return anything. Since this option is
not set until chiselMain is called, having this expression as a val will
result in "line" being evaluated at a point when "getLineNumbers" is
always false, so "line" will always be null. This commit fixes that
issue.
