### PR TITLE
Bundle.calcElements calculates too many #295.

### DIFF
--- a/src/main/scala/Bundle.scala
+++ b/src/main/scala/Bundle.scala
@@ -85,6 +85,7 @@ class Bundle(view_arg: Seq[String] = null) extends Aggregate {
 
       // TODO: SPLIT THIS OUT TO TOP LEVEL LIST
       if( types.length == 0 && !isStatic(modifiers) && isInterface
+        && !(name contains '$')
         && !(Bundle.keywords contains name)
         && (view == null || view.contains(name)) ) {
         val o = m.invoke(this);


### PR DESCRIPTION
Ignore methods with '$' in their name, as they are compiler generated,
and their semantics are unspecified.
