### PR TITLE
Simplify width inference to reduce the opportunity to make mistakes - fix #325

### DIFF
--- a/src/main/scala/Backend.scala
+++ b/src/main/scala/Backend.scala
@@ -469,7 +469,7 @@ abstract class Backend extends FileSystemUtilities{
 
   def inferAll(mod: Module): Int = {
     val nodesList = ArrayBuffer[Node]()
-    Driver.bfs { nodesList += _ }
+    Driver.idfs { nodesList += _ }
 
     def verify {
       var hasError = false
@@ -511,7 +511,7 @@ abstract class Backend extends FileSystemUtilities{
   }
 
   def forceMatchingWidths {
-    Driver.bfs (_.forceMatchingWidths)
+    Driver.idfs (_.forceMatchingWidths)
   }
 
   def computeMemPorts(mod: Module) {

--- a/src/main/scala/Driver.scala
+++ b/src/main/scala/Driver.scala
@@ -210,83 +210,73 @@ object Driver extends FileSystemUtilities{
 
   // A "depth-first" search for width inference.
   def idfs(visit: Node => Unit): Unit = {
+    // We "flag" stack items to indicate whether we've dealt with their children or not.
+    val res = new Stack[(Node, Boolean)]
+    val inputs = new Stack[(Node, Boolean)]
+    val stacked = new HashSet[Node]
 
-    def initializeIDFS: Stack[Node] = {
-      val res = new Stack[Node]
-      /* XXX Make sure roots are consistent between initializeBFS, initializeDFS
-         and findRoots.
-       */
-      for (c <- components; a <- c.debugs)
-        res.push(a)
-      for(b <- blackboxes)
-        res.push(b.io)
-      for(c <- components; (n, io) <- c.io.flatten)
-          res.push(io)
-    res
-    }
-
-
-    // Walk each of the strongly connected component lists,
-    //  visiting nodes as we do so.
-    val visited = new HashSet[Node]
-
-    // Visit a node and reset it's sccIndex as we do so.
-    def doOneNode(n: Node): Unit = {
-      visit(n)
-      visited += n
-      n.sccIndex = -1
-      n.sccLowlink = -1
-    }
-
-    def findSCC():ArrayBuffer[ArrayBuffer[Node]] = {
-      // Tarjan's strongly connected components algorithm to find loops
-      var sccIndex = 0
-      val stack = new Stack[Node]
-      val sccList = new ArrayBuffer[ArrayBuffer[Node]]
-
-      def tarjanSCC(n: Node): Unit = {
-
-        n.sccIndex = sccIndex
-        n.sccLowlink = sccIndex
-        sccIndex += 1
-        stack.push(n)
-
-        for(i <- n.inputs) {
-          if(!(i == null)) {
-            if(i.sccIndex == -1) {
-              tarjanSCC(i)
-              n.sccLowlink = min(n.sccLowlink, i.sccLowlink)
-            } else if(stack.contains(i)) {
-              n.sccLowlink = min(n.sccLowlink, i.sccIndex)
-            }
+    // Order the stack so input nodes are handled first.
+    def pushInitialNode(n: Node) {
+      if (!stacked.contains(n)) {
+        stacked += n
+        n match {
+          case b: Bits if b.isIo && b.dir == INPUT => {
+            inputs.push((n, false))
+          }
+          case _ => {
+            res.push((n, false))
           }
         }
-
-        if(n.sccLowlink == n.sccIndex) {
-          val scc = new ArrayBuffer[Node]
-
-          var top: Node = null
-          do {
-            top = stack.pop()
-            scc += top
-          } while (!(n == top))
-          sccList += scc
-        }
       }
+    }
+    for (c <- components; a <- c.debugs)
+      pushInitialNode(a)
+    for(b <- blackboxes)
+      pushInitialNode(b.io)
+    for(c <- components; (n, io) <- c.io.flatten) {
+      pushInitialNode(io)
+    }
+    val stack = inputs ++ res
 
-      // Construct the SCC arrays
-      val idfsNodes = initializeIDFS
-      for (node <- idfsNodes) {
-        if(node.sccIndex == -1) {
-          tarjanSCC(node)
-        }
-      }
-    sccList
+    // Callers should ensure the node we're pushing isn't already on the stack.
+    def pushBareNode(n: Node) {
+      require(!stacked.contains(n), "idfs: pushNode() node on stack <%s>".format(n.toString()))
+      stacked += n
+      stack.push((n, false))
     }
 
-    for (scclist <- findSCC()) {
-      for (node <- scclist){
-        doOneNode(node)
+    // Walk the graph in depth-first order,
+    //  visiting nodes as we do so.
+    while (!stack.isEmpty) {
+      val (top, dealtWithChildren) = stack.pop
+      // Have we visited all our children
+      if (dealtWithChildren) {
+        // Yes. Visit this node.
+        visit(top)
+      } else {
+        // We still have children to visit.
+        // Put this node back on the stack, with a flag indicating we've dealt with its children
+        stack push ((top, true))
+        top match {
+          case v: Vec[_] => {
+            for ((n, e) <- v.flatten;
+            if !(stacked contains e)) {
+              pushBareNode(e)
+            }
+          }
+          case b: Bundle => {
+            for ((n, e) <- b.flatten;
+            if !(stacked contains e)) {
+              pushBareNode(e)
+            }
+          }
+          case _ => {}
+        }
+        // Push any un-visited children
+        for (c <- top.inputs;
+        if !(stacked contains c)) {
+          pushBareNode(c)
+        }
       }
     }
   }

--- a/src/test/scala/ZeroWidthTest.scala
+++ b/src/test/scala/ZeroWidthTest.scala
@@ -437,4 +437,20 @@ class ZeroWidthTest extends TestSuite {
 
     chiselMain(testArgs, () => Module(new MuxComp()))
   }
+
+  /** Reverse produced many width warning messages. 
+    */
+  @Test def testReverseNoisyWidth() {
+    println("\ntesttestReverseNoisyWidth ...")
+    class ReverseNoisyWidth extends Module {
+      val io = new Bundle {
+        val i = UInt(INPUT, width=64)
+        val o = UInt(OUTPUT, width=64)
+      }
+      io.o := Reverse(io.i)
+    }
+
+    chiselMain(testArgs, () => Module(new ReverseNoisyWidth()))
+    assertTrue(ChiselError.ChiselErrors.isEmpty);
+  }
 }


### PR DESCRIPTION
Simplify depth-first search (Driver.idfs) and use it for width-related graph walking.
