### PR TITLE
Add test for issue #335 - Null Pointer Exception on Floating Output.

### DIFF
--- a/src/test/scala/ZeroWidthTest.scala
+++ b/src/test/scala/ZeroWidthTest.scala
@@ -453,4 +453,25 @@ class ZeroWidthTest extends TestSuite {
     chiselMain(testArgs, () => Module(new ReverseNoisyWidth()))
     assertTrue(ChiselError.ChiselErrors.isEmpty);
   }
+
+  /** Issue #335
+   *  When you have an output that is driven inside of a when statement,
+   *   but is left floating in other cases, a java.lang.NullPointerException
+   *    is thrown during "checking widths".
+   */
+  @Test def testUnRefOutNullPointer() {
+    println("\ntestUnRefOutNullPointer ...")
+    class FloatOutModule extends Module {
+    
+      val io = new Bundle {
+        val i_value     = UInt(INPUT, width = 64)
+        val i_valid     = Bool(INPUT)
+        val o_value     = UInt(OUTPUT, width = 64)
+      }
+    
+      when ( io.i_valid ) {
+        io.o_value := io.i_value
+      }
+    }
+  }
 }


### PR DESCRIPTION
This appears to have been fixed with pr #336 which rewrote the width
inference process.
