### PR TITLE
move verifyAllMuxes before width inference(issue #335)

### DIFF
--- a/src/main/scala/Backend.scala
+++ b/src/main/scala/Backend.scala
@@ -811,6 +811,7 @@ abstract class Backend extends FileSystemUtilities{
 
     ChiselError.info("executing custom transforms")
     execute(c, transforms)
+    verifyAllMuxes
     ChiselError.checkpoint()
 
     ChiselError.info("adding clocks and resets")
@@ -853,7 +854,6 @@ abstract class Backend extends FileSystemUtilities{
     ChiselError.info("resolving nodes to the components")
     collectNodesIntoComp(c)
     checkModuleResolution
-    verifyAllMuxes
     ChiselError.checkpoint()
 
     findConsumers(c)


### PR DESCRIPTION
I moved verifyAllMuxes before width inference. Now it will inform like:

[info] [0.037] // COMPILING class TutorialExamples.TestFloating(0)
[info] [0.045] giving names
[info] [0.049] executing custom transforms
[error]: NO DEFAULT SPECIFIED FOR WIRE: /_io_o_value in class TutorialExamples.TestFloating_/ Chisel.UInt(OUTPUT, width=64, connect to 1 inputs: (T0[Chisel.Mux] in TutorialExamples.TestFloating)) in component class TutorialExamples.TestFloating
Re-running Chisel in debug mode to obtain erroneous line numbers...
[info] [0.004] // COMPILING class TutorialExamples.TestFloating(0)
[info] [0.004] giving names
[info] [0.004] executing custom transforms
[error] TestFloating.scala:7: NO DEFAULT SPECIFIED FOR WIRE: /_io_o_value in class TutorialExamples.TestFloating_/ Chisel.UInt(OUTPUT, width=64, connect to 1 inputs: (T0[Chisel.Mux] in TutorialExamples.TestFloating)) in component class TutorialExamples.TestFloating in class TutorialExamples.TestFloating
[error](run-main) java.lang.IllegalStateException: CODE HAS 1 ERRORS and 0 WARNINGS
java.lang.IllegalStateException: CODE HAS 1 ERRORS and 0 WARNINGS
    at Chisel.ChiselError$.checkpoint(ChiselError.scala:128)
    at Chisel.Backend.elaborate(Backend.scala:826)
    at Chisel.VerilogBackend.elaborate(Verilog.scala:1038)
    at Chisel.Driver$.execute(Driver.scala:93)
    at Chisel.Driver$.apply(Driver.scala:40)
    at Chisel.Driver$.apply(Driver.scala:45)
    at Chisel.chiselMain$.apply(hcl.scala:59)
    at TutorialExamples.TutorialExamples$.main(examples.scala:96)
    at TutorialExamples.TutorialExamples.main(examples.scala)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
[trace] Stack trace suppressed: run last tests/compile:run for the full output.
java.lang.RuntimeException: Nonzero exit code: 1
    at scala.sys.package$.error(package.scala:27)
[trace] Stack trace suppressed: run last tests/compile:run for the full output.
[error](tests/compile:run) Nonzero exit code: 1
[error] Total time: 51 s, completed Nov 21, 2014 1:47:25 PM
