### PR TITLE
Various -Wextra fixups

### DIFF
--- a/src/main/resources/emulator_api.h
+++ b/src/main/resources/emulator_api.h
@@ -4,6 +4,12 @@
 
 #include "emulator_mod.h"
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-variable"
+
 #include <string>
 #include <sstream>
 #include <map>
@@ -23,7 +29,7 @@ static std::string itos(int in) {
  * Copy one val_t array to another.
  * nb must be the exact number of bits the val_t represents.
  */
-static void val_cpy(val_t* dst, val_t* src, int nb) {
+static __attribute__((unused)) void val_cpy(val_t* dst, val_t* src, int nb) {
     for (int i=0; i<val_n_words(nb); i++) {
         dst[i] = src[i];
     }
@@ -44,7 +50,7 @@ static void val_empty(val_t* dst, int nb) {
  * is capped by the width of a single val_t element.
  * nb must be the exact number of bits the val_t represents.
  */
-static void val_set(val_t* dst, val_t nb, val_t num) {
+static __attribute__((unused)) void val_set(val_t* dst, val_t nb, val_t num) {
     val_empty(dst, nb);
     dst[0] = num;
 }
@@ -659,5 +665,7 @@ protected:
 	// Snapshot functions
 	std::map<std::string, mod_t*> snapshot_table;
 };
+
+#pragma GCC diagnostic pop
 
 #endif

--- a/src/main/resources/emulator_mod.h
+++ b/src/main/resources/emulator_mod.h
@@ -5,6 +5,7 @@
 #define __IS_EMULATOR_MOD__
 
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #pragma GCC diagnostic ignored "-Wparentheses"
@@ -13,6 +14,9 @@
 #pragma GCC diagnostic ignored "-Wtype-limits"
 #pragma GCC diagnostic ignored "-Wunused-function"
 #pragma GCC diagnostic ignored "-Wunused-variable"
+#pragma GCC diagnostic ignored "-Wreorder"
+#pragma GCC diagnostic ignored "-Wsometimes-uninitialized"
+#pragma GCC diagnostic ignored "-pedantic"
 
 #include <assert.h>
 #include <inttypes.h>
@@ -1564,7 +1568,7 @@ class mem_t {
   }
 };
 
-static char hex_to_char[] = "0123456789abcdef";
+static __attribute__((unused)) char hex_to_char[] = "0123456789abcdef";
 
 static int  char_to_hex[] = {
   -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,


### PR DESCRIPTION
It appears that some more errors have either creeped into the Chisel
C++ header files or into GCC's "-Wextra -pedantic" set.  This patch
uses the same techniques as last time to hide these new errors.
