### PR TITLE
Generate valid literal node names for the Dot backend.

### DIFF
--- a/src/main/scala/Dot.scala
+++ b/src/main/scala/Dot.scala
@@ -49,6 +49,10 @@ class DotBackend extends Backend {
         if (r.name == "") {
           r.name = "R" + r.emitIndex
         }
+      // If we're explicitly outputting literal nodes, make sure they have a legitimate name and not just a number.
+      case l: Literal => if (allDottable) {
+        return "L" + l.toString
+      }
       case _ =>
         if(node.name == "") {
           node.name = "T" + node.emitIndex


### PR DESCRIPTION
If we're explicitly outputting literal nodes, make sure they have a legitimate name and not just a number (otherwise, the dot file processor complains about an illegal number when it parses the name).
