### PR TITLE
Apply require() to converted variable in emitLit().

### DIFF
--- a/src/main/scala/Verilog.scala
+++ b/src/main/scala/Verilog.scala
@@ -130,7 +130,7 @@ class VerilogBackend extends Backend {
     emitLit(x, x.bitLength + (if (x < 0) 1 else 0))
   private def emitLit(x: BigInt, w: Int): String = {
     val unsigned = if (x < 0) (BigInt(1) << w) + x else x
-    require(x >= 0)
+    require(unsigned >= 0)
     w + "'h" + unsigned.toString(16)
   }
 


### PR DESCRIPTION
Change #349 inadvertently broke Verilog generation by introducing negative literals that ran afoul of a require test. We assume this was due to an inadvertent typo in the test itself.
