### PR TITLE
A fix for #356: Tester.expect always results a PASS on data wider than 3...

### DIFF
--- a/src/main/scala/Tester.scala
+++ b/src/main/scala/Tester.scala
@@ -281,7 +281,7 @@ class ManualTester[+T <: Module]
   }
 
   def expect (data: Bits, expected: BigInt): Boolean = {
-    val mask = BigInt((1 << data.needWidth) - 1)
+    val mask = (BigInt(1) << data.needWidth) - 1
     val got = peek(data)
 
     expect((got & mask) == (expected & mask),


### PR DESCRIPTION
...2 bits, even when signal value does not much the expected value