### PR TITLE
Support Quartus' variant of `ifndef SYNTHESIS

### DIFF
--- a/src/main/scala/Verilog.scala
+++ b/src/main/scala/Verilog.scala
@@ -242,13 +242,13 @@ class VerilogBackend extends Backend {
     res += portDecs.map(_.result).reduceLeft(_ + "\n" + _)
     res += "\n  );\n";
     if (c.wires.map(_._2.driveRand).reduceLeft(_ || _)) {
-      res += "  `ifndef SYNTHESIS\n"
+      res += if_not_synthesis
       for ((n, w) <- c.wires) {
         if (w.driveRand) {
           res += "    assign " + c.name + "." + n + " = " + emitRand(w) + ";\n"
         }
       }
-      res += "  `endif\n"
+      res += endif_not_synthesis
     }
     res
   }
@@ -355,11 +355,12 @@ class VerilogBackend extends Backend {
           inits append s"    ${i}: ${emitRef(r)} = ${emitRef(v)};\n"
         s"  always @(*) case (${emitRef(r.inputs.head)})\n" +
         inits +
-        "`ifndef SYNTHESIS\n" +
-        s"    default: ${emitRef(r)} = ${emitRand(r)};\n" +
-        "`else\n" +
-        s"    default: ${emitRef(r)} = ${r.needWidth()}'bx;\n" +
-        "`endif\n" +
+        s"    default: begin\n" +
+        s"      ${emitRef(r)} = ${r.needWidth()}'bx;\n" +
+        if_not_synthesis +
+        s"      ${emitRef(r)} = ${emitRand(r)};\n" +
+        endif_not_synthesis +
+        s"    end\n" +
         "  endcase\n"
 
       case s: Sprintf =>
@@ -775,22 +776,22 @@ class VerilogBackend extends Backend {
   }
 
   def emitPrintf(p: Printf): String = {
-    "`ifndef SYNTHESIS\n" +
+    if_not_synthesis +
     "`ifdef PRINTF_COND\n" +
     "    if (`PRINTF_COND)\n" +
     "`endif\n" +
     "      if (" + emitRef(p.cond) + ")\n" +
     "        $fwrite(32'h80000002, " + p.args.map(emitRef _).foldLeft(CString(p.format))(_ + ", " + _) + ");\n" +
-    "`endif\n"
+    endif_not_synthesis
   }
   def emitAssert(a: Assert): String = {
-    "`ifndef SYNTHESIS\n" +
+    if_not_synthesis +
     "  if(" + emitRef(a.reset) + ") " + emitRef(a) + " <= 1'b1;\n" +
     "  if(!" + emitRef(a.cond) + " && " + emitRef(a) + " && !" + emitRef(a.reset) + ") begin\n" +
     "    $fwrite(32'h80000002, " + CString("ASSERTION FAILED: %s\n") + ", " + CString(a.message) + ");\n" +
     "    $finish;\n" +
     "  end\n" +
-    "`endif\n"
+    endif_not_synthesis
   }
 
   def emitReg(node: Node): String = {
@@ -828,13 +829,13 @@ class VerilogBackend extends Backend {
 
     val res = new StringBuilder
     if (!sb.isEmpty) {
-      res append "`ifndef SYNTHESIS\n"
+      res append if_not_synthesis
       res append "  integer initvar;\n"
       res append "  initial begin\n"
       res append "    #0.002;\n"
       res append sb
       res append "  end\n"
-      res append "`endif\n"
+      res append endif_not_synthesis
     }
     res
   }
@@ -1022,5 +1023,8 @@ class VerilogBackend extends Backend {
               "+vcs+initreg+random " + src + " -o " + n + " -debug_pp"
     run(cmd)
   }
+
+  private def if_not_synthesis = "`ifndef SYNTHESIS\n// synthesis translate_off\n"
+  private def endif_not_synthesis = "// synthesis translate_on\n`endif\n"
 }
 

--- a/src/test/resources/ConnectSuite_UnconnectedResets_1.v
+++ b/src/test/resources/ConnectSuite_UnconnectedResets_1.v
@@ -7,11 +7,13 @@ module ConnectSuite_SubModule_1(input clk, input reset,
   wire T0;
 
 `ifndef SYNTHESIS
+// synthesis translate_off
   integer initvar;
   initial begin
     #0.002;
     r = {1{$random}};
   end
+// synthesis translate_on
 `endif
 
   assign io_out = r;
@@ -37,6 +39,7 @@ module ConnectSuite_UnconnectedResets_1(input clk, input reset,
   wire sub_io_out;
 
 `ifndef SYNTHESIS
+// synthesis translate_off
   integer initvar;
   initial begin
     #0.002;
@@ -44,6 +47,7 @@ module ConnectSuite_UnconnectedResets_1(input clk, input reset,
     regs_1 = {1{$random}};
     regs_0 = {1{$random}};
   end
+// synthesis translate_on
 `endif
 
   assign io_out = sub_io_out;

--- a/src/test/resources/DelaySuite_MemReadModule_1.v
+++ b/src/test/resources/DelaySuite_MemReadModule_1.v
@@ -8,12 +8,14 @@ module DelaySuite_MemReadModule_1(input clk,
   wire[2:0] T1;
 
 `ifndef SYNTHESIS
+// synthesis translate_off
   integer initvar;
   initial begin
     #0.002;
     for (initvar = 0; initvar < 8; initvar = initvar+1)
       mem[initvar] = {1{$random}};
   end
+// synthesis translate_on
 `endif
 
   assign io_out = T0;

--- a/src/test/resources/DelaySuite_ROMModule_1.v
+++ b/src/test/resources/DelaySuite_ROMModule_1.v
@@ -11,11 +11,14 @@ module DelaySuite_ROMModule_1(
     0: T0 = 4'h1;
     1: T0 = 4'h2;
     2: T0 = 4'h3;
+    default: begin
+      T0 = 4'bx;
 `ifndef SYNTHESIS
-    default: T0 = {1{$random}};
-`else
-    default: T0 = 4'bx;
+// synthesis translate_off
+      T0 = {1{$random}};
+// synthesis translate_on
 `endif
+    end
   endcase
 endmodule
 

--- a/src/test/resources/DelaySuite_ReadCondMaskedWrite_1.v
+++ b/src/test/resources/DelaySuite_ReadCondMaskedWrite_1.v
@@ -14,12 +14,14 @@ module DelaySuite_ReadCondMaskedWrite_1(input clk,
   wire[2:0] T6;
 
 `ifndef SYNTHESIS
+// synthesis translate_off
   integer initvar;
   initial begin
     #0.002;
     for (initvar = 0; initvar < 8; initvar = initvar+1)
       mem[initvar] = {1{$random}};
   end
+// synthesis translate_on
 `endif
 
   assign io_out = T0;

--- a/src/test/resources/DelaySuite_ReadCondWriteModule_1.v
+++ b/src/test/resources/DelaySuite_ReadCondWriteModule_1.v
@@ -18,12 +18,14 @@ module DelaySuite_ReadCondWriteModule_1(input clk,
   wire[2:0] T10;
 
 `ifndef SYNTHESIS
+// synthesis translate_off
   integer initvar;
   initial begin
     #0.002;
     for (initvar = 0; initvar < 8; initvar = initvar+1)
       mem[initvar] = {1{$random}};
   end
+// synthesis translate_on
 `endif
 
   assign io_out = T0;

--- a/src/test/resources/DelaySuite_ReadWriteModule_1.v
+++ b/src/test/resources/DelaySuite_ReadWriteModule_1.v
@@ -11,12 +11,14 @@ module DelaySuite_ReadWriteModule_1(input clk,
   wire[2:0] T4;
 
 `ifndef SYNTHESIS
+// synthesis translate_off
   integer initvar;
   initial begin
     #0.002;
     for (initvar = 0; initvar < 8; initvar = initvar+1)
       mem[initvar] = {1{$random}};
   end
+// synthesis translate_on
 `endif
 
   assign io_out = T0;

--- a/src/test/resources/DelaySuite_RegInitCondUpdate_1.v
+++ b/src/test/resources/DelaySuite_RegInitCondUpdate_1.v
@@ -10,11 +10,13 @@ module DelaySuite_RegInitCondUpdate_1(input clk, input reset,
   wire T1;
 
 `ifndef SYNTHESIS
+// synthesis translate_off
   integer initvar;
   initial begin
     #0.002;
     res = {1{$random}};
   end
+// synthesis translate_on
 `endif
 
   assign io_out = T2;

--- a/src/test/resources/DelaySuite_RegInitUpdate_1.v
+++ b/src/test/resources/DelaySuite_RegInitUpdate_1.v
@@ -8,11 +8,13 @@ module DelaySuite_RegInitUpdate_1(input clk, input reset,
   wire T0;
 
 `ifndef SYNTHESIS
+// synthesis translate_off
   integer initvar;
   initial begin
     #0.002;
     res = {1{$random}};
   end
+// synthesis translate_on
 `endif
 
   assign io_out = T1;

--- a/src/test/resources/DelaySuite_RegNoInitUpdate_1.v
+++ b/src/test/resources/DelaySuite_RegNoInitUpdate_1.v
@@ -6,11 +6,13 @@ module DelaySuite_RegNoInitUpdate_1(input clk,
   wire[31:0] T0;
 
 `ifndef SYNTHESIS
+// synthesis translate_off
   integer initvar;
   initial begin
     #0.002;
     res = {1{$random}};
   end
+// synthesis translate_on
 `endif
 
   assign io_out = res;

--- a/src/test/resources/MultiClockSuite_Comp_1.v
+++ b/src/test/resources/MultiClockSuite_Comp_1.v
@@ -6,11 +6,13 @@ module MultiClockSuite_ClockedSubComp_1(input T0,
   reg  stored;
 
 `ifndef SYNTHESIS
+// synthesis translate_off
   integer initvar;
   initial begin
     #0.002;
     stored = {1{$random}};
   end
+// synthesis translate_on
 `endif
 
   assign io_valid = stored;

--- a/src/test/resources/MultiClockSuite_TestMultiClock2_1.v
+++ b/src/test/resources/MultiClockSuite_TestMultiClock2_1.v
@@ -6,11 +6,13 @@ module MultiClockSuite_TestMultiClock2_1_TestMultiClock2_subsub(input clkB,
   reg  r1_onSignal;
 
 `ifndef SYNTHESIS
+// synthesis translate_off
   integer initvar;
   initial begin
     #0.002;
     r1_onSignal = {1{$random}};
   end
+// synthesis translate_on
 `endif
 
   assign io_out = r1_onSignal;

--- a/src/test/resources/NameSuite_BindFifthComp_1.v
+++ b/src/test/resources/NameSuite_BindFifthComp_1.v
@@ -24,12 +24,14 @@ module NameSuite_Block_2(input clk,
   wire T12;
 
 `ifndef SYNTHESIS
+// synthesis translate_off
   integer initvar;
   initial begin
     #0.002;
     tag_ram_1 = {1{$random}};
     tag_ram_0 = {1{$random}};
   end
+// synthesis translate_on
 `endif
 
   assign io_out_resp_bits_ppn = T0;
@@ -85,9 +87,11 @@ module NameSuite_BindFifthComp_1(input clk,
        .io_out_resp_bits_error( vdtlb_io_out_resp_bits_error ),
        .io_out_resp_bits_ppn( vdtlb_io_out_resp_bits_ppn )
   );
-  `ifndef SYNTHESIS
+`ifndef SYNTHESIS
+// synthesis translate_off
     assign vdtlb.io_out_resp_valid = {1{$random}};
     assign vdtlb.io_out_resp_bits_error = {1{$random}};
-  `endif
+// synthesis translate_on
+`endif
 endmodule
 

--- a/src/test/resources/NameSuite_BindFirstComp_1.v
+++ b/src/test/resources/NameSuite_BindFirstComp_1.v
@@ -38,10 +38,12 @@ module NameSuite_BindFirstComp_1(
        .io_sigs_enq_cmdq( dec_io_sigs_enq_cmdq ),
        .io_sigs_enq_ximm1q( dec_io_sigs_enq_ximm1q )
   );
-  `ifndef SYNTHESIS
+`ifndef SYNTHESIS
+// synthesis translate_off
     assign dec.io_valid = {1{$random}};
     assign dec.io_sigs_enq_cmdq = {1{$random}};
     assign dec.io_sigs_enq_ximm1q = {1{$random}};
-  `endif
+// synthesis translate_on
+`endif
 endmodule
 

--- a/src/test/resources/NameSuite_MemComp_1.v
+++ b/src/test/resources/NameSuite_MemComp_1.v
@@ -9,11 +9,13 @@ module NameSuite_MemComp_1(input clk,
   wire[7:0] T1;
 
 `ifndef SYNTHESIS
+// synthesis translate_off
   integer initvar;
   initial begin
     #0.002;
     raddr = {1{$random}};
   end
+// synthesis translate_on
 `endif
 
   assign io_rdata = T0;

--- a/src/test/resources/NameSuite_VecComp_1.v
+++ b/src/test/resources/NameSuite_VecComp_1.v
@@ -16,12 +16,14 @@ module NameSuite_VecComp_1(input clk,
   wire[7:0] elts_0;
 
 `ifndef SYNTHESIS
+// synthesis translate_off
   integer initvar;
   initial begin
     #0.002;
     reg_status_im = {1{$random}};
     host_pcr_bits_data = {2{$random}};
   end
+// synthesis translate_on
 `endif
 
   assign io_status_im = reg_status_im;

--- a/src/test/resources/NameSuite_VecSecondComp_1.v
+++ b/src/test/resources/NameSuite_VecSecondComp_1.v
@@ -24,6 +24,7 @@ module NameSuite_VecSecondComp_1(input clk,
   reg  r_valid_3;
 
 `ifndef SYNTHESIS
+// synthesis translate_off
   integer initvar;
   initial begin
     #0.002;
@@ -32,6 +33,7 @@ module NameSuite_VecSecondComp_1(input clk,
     r_valid_2 = {1{$random}};
     r_valid_3 = {1{$random}};
   end
+// synthesis translate_on
 `endif
 
   assign io_mem = T0;

--- a/src/test/resources/StdlibSuite_PipeComp_1.v
+++ b/src/test/resources/StdlibSuite_PipeComp_1.v
@@ -15,6 +15,7 @@ module StdlibSuite_PipeComp_1(input clk, input reset,
   wire T7;
 
 `ifndef SYNTHESIS
+// synthesis translate_off
   integer initvar;
   initial begin
     #0.002;
@@ -23,6 +24,7 @@ module StdlibSuite_PipeComp_1(input clk, input reset,
     R4 = {1{$random}};
     R5 = {1{$random}};
   end
+// synthesis translate_on
 `endif
 
   assign io_deq_bits = R0;

--- a/src/test/resources/StdlibSuite_QueueComp_1.v
+++ b/src/test/resources/StdlibSuite_QueueComp_1.v
@@ -36,6 +36,7 @@ module Queue(input clk, input reset,
   wire full;
 
 `ifndef SYNTHESIS
+// synthesis translate_off
   integer initvar;
   initial begin
     #0.002;
@@ -45,6 +46,7 @@ module Queue(input clk, input reset,
     for (initvar = 0; initvar < 2; initvar = initvar+1)
       ram[initvar] = {1{$random}};
   end
+// synthesis translate_on
 `endif
 
   assign io_count = T0;

--- a/src/test/resources/StdlibSuite_RRArbiterTest_1.v
+++ b/src/test/resources/StdlibSuite_RRArbiterTest_1.v
@@ -100,11 +100,13 @@ module StdlibSuite_RRArbiterTest_1(input clk, input reset,
   wire T76;
 
 `ifndef SYNTHESIS
+// synthesis translate_off
   integer initvar;
   initial begin
     #0.002;
     last_grant = {1{$random}};
   end
+// synthesis translate_on
 `endif
 
   assign io_chosen = chosen;

--- a/src/test/resources/VerifSuite_VerilogAssertComp_1.v
+++ b/src/test/resources/VerifSuite_VerilogAssertComp_1.v
@@ -8,11 +8,13 @@ module VerifSuite_VerilogAssertComp_1(input clk, input reset,
   wire[15:0] T1;
 
 `ifndef SYNTHESIS
+// synthesis translate_off
   integer initvar;
   initial begin
     #0.002;
     T0 = 1'b0;
   end
+// synthesis translate_on
 `endif
 
   assign io_z = T1;
@@ -20,11 +22,13 @@ module VerifSuite_VerilogAssertComp_1(input clk, input reset,
 
   always @(posedge clk) begin
 `ifndef SYNTHESIS
+// synthesis translate_off
   if(reset) T0 <= 1'b1;
   if(!reset && T0 && !reset) begin
     $fwrite(32'h80000002, "ASSERTION FAILED: %s\n", "failure");
     $finish;
   end
+// synthesis translate_on
 `endif
   end
 endmodule

--- a/src/test/resources/VerifSuite_VerilogPrintfComp_1.v
+++ b/src/test/resources/VerifSuite_VerilogPrintfComp_1.v
@@ -16,11 +16,13 @@ module VerifSuite_VerilogPrintfComp_1(input clk, input reset,
   wire[15:0] T7;
 
 `ifndef SYNTHESIS
+// synthesis translate_off
   integer initvar;
   initial begin
     #0.002;
     tsc_reg = {1{$random}};
   end
+// synthesis translate_on
 `endif
 
   assign T0 = reset ^ 1'h1;
@@ -40,11 +42,13 @@ module VerifSuite_VerilogPrintfComp_1(input clk, input reset,
       tsc_reg <= T5;
     end
 `ifndef SYNTHESIS
+// synthesis translate_off
 `ifdef PRINTF_COND
     if (`PRINTF_COND)
 `endif
       if (T0)
         $fwrite(32'h80000002, "Cyc= %d io: %h %h", T3, T2, T1);
+// synthesis translate_on
 `endif
   end
 endmodule

--- a/src/test/resources/VerifSuite_VerilogPrintfNULComp_1.v
+++ b/src/test/resources/VerifSuite_VerilogPrintfNULComp_1.v
@@ -12,11 +12,13 @@ module VerifSuite_VerilogPrintfNULComp_1(input clk, input reset,
 
   always @(posedge clk) begin
 `ifndef SYNTHESIS
+// synthesis translate_off
 `ifdef PRINTF_COND
     if (`PRINTF_COND)
 `endif
       if (T0)
         $fwrite(32'h80000002, "%b\n", T1);
+// synthesis translate_on
 `endif
   end
 endmodule


### PR DESCRIPTION
Several tools define SYNTHESIS for the Verilog preprocessor when performing
synthesis, as opposed to simulation.  Quartus doesn't, but it is part of a
handful of tools that respect //comment directives that have the same
effect.  So emit both.