### PR TITLE
Don't publish the instrumented version of the code.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ clean:
 	$(RM) -r $(RM_DIRS)
 
 jenkins-build: clean
-	$(SBT) $(SBT_FLAGS) scalastyle coverage +test +publish-local
+	$(SBT) $(SBT_FLAGS) scalastyle coverage +test
+	$(SBT) $(SBT_FLAGS) +clean +publish-local
 	$(SBT) $(SBT_FLAGS) coverageReport
 
 sysctest:


### PR DESCRIPTION
The instrumented version of the code (sbt test) contains references to the instrumentation modules, requiring clients to include those packages with their code.