### PR TITLE
Fix for issue #374 - add backend specific name scoping

### DIFF
--- a/src/main/scala/Backend.scala
+++ b/src/main/scala/Backend.scala
@@ -130,8 +130,7 @@ abstract class Backend extends FileSystemUtilities{
     if (keywords.contains(name)) name + "_" else name;
   }
 
-  def nameAll(mod: Module) {
-    // module naming
+  def scopeNames() {
     val byNames = LinkedHashMap[String, ArrayBuffer[Module]]();
     for (c <- Driver.sortedComps) {
       if( c.name.isEmpty ) {
@@ -145,7 +144,6 @@ abstract class Backend extends FileSystemUtilities{
         }
       }
     }
-
     for( (className, comps) <- byNames ) {
       if( comps.length > 1 ) {
         for( (c, index) <- comps.zipWithIndex ) {
@@ -155,6 +153,14 @@ abstract class Backend extends FileSystemUtilities{
         comps(0).name = className;
       }
     }
+  }
+
+  def nameAll(mod: Module) {
+    // module naming
+
+    // Apply whatever name scoping rules are appropriate for the backend.
+    scopeNames()
+
     // temporary node naming:
     // these names are for the Verilog Backend
     // and used in custom transforms such as backannotation

--- a/src/main/scala/Verilog.scala
+++ b/src/main/scala/Verilog.scala
@@ -1064,35 +1064,38 @@ class VerilogBackend extends Backend {
   // We do this in order to share submodules (issue #374  - Multiply instantiated modules in Chisel
   //  result in redundant (functionally equivalent) module definitions in generated Verilog.
   override def scopeNames() {
-    if (false) {
-      super.scopeNames()
-    } else {
-      // We assume the LinkedHashMap has been built from the inputs (children) up. 
-      val byNames = LinkedHashMap[String, ArrayBuffer[Module]]();
-      for (c <- Driver.sortedComps) {
-        if( c.name.isEmpty ) {
-          /* We don't have a name because we are not dealing with
-           a class member. */
-          val className = extractClassName(c);
-          if( byNames contains className ) {
-            byNames(className) += c
-          } else {
-            byNames(className) = ArrayBuffer[Module](c)
-          }
+    // We assume the LinkedHashMap has been built from the inputs (children) up.
+    // This duplicates code in Backend::scopeNames(), but we do so in order
+    // to control how the byNames Map is constructed.
+    val byNames = LinkedHashMap[String, ArrayBuffer[Module]]();
+    for (c <- Driver.sortedComps) {
+      if( c.name.isEmpty ) {
+        /* We don't have a name because we are not dealing with
+         a class member. */
+        val className = extractClassName(c);
+        if( byNames contains className ) {
+          byNames(className) += c
+        } else {
+          byNames(className) = ArrayBuffer[Module](c)
         }
       }
-      for( (className, comps) <- byNames ) {
-        if( comps.length > 1 ) {
-          // Group modules by their parents.
-          val compByParent = comps.groupBy(_.parent)
-          for ( (p, ml) <- compByParent) {
-            for (i <- 0 until ml.length) {
-              ml(i).name = className + "_" + i
-            }
+    }
+    // We only need unique names on a per-module basis, and in fact,
+    //  we want sub-modules to have the same names within their common
+    //  parent, so our simple module merging code works.
+    for( (className, comps) <- byNames ) {
+      if( comps.length > 1 ) {
+        // Group modules by their parents.
+        val compByParent = comps.groupBy(_.parent)
+        // Ensure that multiple sub-modules within a parent
+        //  have unique names.
+        for ( (p, ml) <- compByParent) {
+          for (i <- 0 until ml.length) {
+            ml(i).name = className + "_" + i
           }
-        } else {
-          comps(0).name = className;
         }
+      } else {
+        comps(0).name = className;
       }
     }
   }

--- a/src/main/scala/Verilog.scala
+++ b/src/main/scala/Verilog.scala
@@ -1059,5 +1059,43 @@ class VerilogBackend extends Backend {
 
   private def if_not_synthesis = "`ifndef SYNTHESIS\n// synthesis translate_off\n"
   private def endif_not_synthesis = "// synthesis translate_on\n`endif\n"
+
+  // The Verilog backend provides its own name scoping code.
+  // We do this in order to share submodules (issue #374  - Multiply instantiated modules in Chisel
+  //  result in redundant (functionally equivalent) module definitions in generated Verilog.
+  override def scopeNames() {
+    if (false) {
+      super.scopeNames()
+    } else {
+      // We assume the LinkedHashMap has been built from the inputs (children) up. 
+      val byNames = LinkedHashMap[String, ArrayBuffer[Module]]();
+      for (c <- Driver.sortedComps) {
+        if( c.name.isEmpty ) {
+          /* We don't have a name because we are not dealing with
+           a class member. */
+          val className = extractClassName(c);
+          if( byNames contains className ) {
+            byNames(className) += c
+          } else {
+            byNames(className) = ArrayBuffer[Module](c)
+          }
+        }
+      }
+      for( (className, comps) <- byNames ) {
+        if( comps.length > 1 ) {
+          // Group modules by their parents.
+          val compByParent = comps.groupBy(_.parent)
+          for ( (p, ml) <- compByParent) {
+            for (i <- 0 until ml.length) {
+              ml(i).name = className + "_" + i
+            }
+          }
+        } else {
+          comps(0).name = className;
+        }
+      }
+    }
+  }
+
 }
 

--- a/src/test/resources/VerilogMultiModule_MultiMultiFIR_2.v
+++ b/src/test/resources/VerilogMultiModule_MultiMultiFIR_2.v
@@ -1,0 +1,241 @@
+module VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection(
+    output io_in_ready,
+    input  io_in_valid,
+    input [31:0] io_in_bits,
+    input  io_out_ready,
+    output io_out_valid,
+    output[31:0] io_out_bits
+);
+
+  wire[31:0] T0;
+
+
+  assign io_out_bits = T0;
+  assign T0 = io_in_bits f* 32'h40000000;
+  assign io_out_valid = io_in_valid;
+  assign io_in_ready = io_out_ready;
+endmodule
+
+module Queue(input clk, input reset,
+    output io_enq_ready,
+    input  io_enq_valid,
+    input [31:0] io_enq_bits,
+    input  io_deq_ready,
+    output io_deq_valid,
+    output[31:0] io_deq_bits,
+    output[2:0] io_count
+);
+
+  wire[2:0] T0;
+  wire[1:0] ptr_diff;
+  reg [1:0] R1;
+  wire[1:0] T16;
+  wire[1:0] T2;
+  wire[1:0] T3;
+  wire do_deq;
+  reg [1:0] R4;
+  wire[1:0] T17;
+  wire[1:0] T5;
+  wire[1:0] T6;
+  wire do_enq;
+  wire T7;
+  wire ptr_match;
+  reg  maybe_full;
+  wire T18;
+  wire T8;
+  wire T9;
+  wire[31:0] T10;
+  reg [31:0] ram [3:0];
+  wire[31:0] T11;
+  wire[31:0] T12;
+  wire T13;
+  wire empty;
+  wire T14;
+  wire T15;
+  wire full;
+
+`ifndef SYNTHESIS
+// synthesis translate_off
+  integer initvar;
+  initial begin
+    #0.002;
+    R1 = {1{$random}};
+    R4 = {1{$random}};
+    maybe_full = {1{$random}};
+    for (initvar = 0; initvar < 4; initvar = initvar+1)
+      ram[initvar] = {1{$random}};
+  end
+// synthesis translate_on
+`endif
+
+  assign io_count = T0;
+  assign T0 = {T7, ptr_diff};
+  assign ptr_diff = R4 - R1;
+  assign T16 = reset ? 2'h0 : T2;
+  assign T2 = do_deq ? T3 : R1;
+  assign T3 = R1 + 2'h1;
+  assign do_deq = io_deq_ready & io_deq_valid;
+  assign T17 = reset ? 2'h0 : T5;
+  assign T5 = do_enq ? T6 : R4;
+  assign T6 = R4 + 2'h1;
+  assign do_enq = io_enq_ready & io_enq_valid;
+  assign T7 = maybe_full & ptr_match;
+  assign ptr_match = R4 == R1;
+  assign T18 = reset ? 1'h0 : T8;
+  assign T8 = T9 ? do_enq : maybe_full;
+  assign T9 = do_enq != do_deq;
+  assign io_deq_bits = T10;
+  assign T10 = ram[R1];
+  assign T12 = io_enq_bits;
+  assign io_deq_valid = T13;
+  assign T13 = empty ^ 1'h1;
+  assign empty = ptr_match & T14;
+  assign T14 = maybe_full ^ 1'h1;
+  assign io_enq_ready = T15;
+  assign T15 = full ^ 1'h1;
+  assign full = ptr_match & maybe_full;
+
+  always @(posedge clk) begin
+    if(reset) begin
+      R1 <= 2'h0;
+    end else if(do_deq) begin
+      R1 <= T3;
+    end
+    if(reset) begin
+      R4 <= 2'h0;
+    end else if(do_enq) begin
+      R4 <= T6;
+    end
+    if(reset) begin
+      maybe_full <= 1'h0;
+    end else if(T9) begin
+      maybe_full <= do_enq;
+    end
+    if (do_enq)
+      ram[R4] <= T12;
+  end
+endmodule
+
+module VerilogMultiModule_MultiMultiFIR_2_MultiFIR(input clk, input reset,
+    output io_in_ready,
+    input  io_in_valid,
+    input [31:0] io_in_bits,
+    input  io_out_ready,
+    output io_out_valid,
+    output[31:0] io_out_bits
+);
+
+  wire VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_0_io_in_ready;
+  wire VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_0_io_out_valid;
+  wire[31:0] VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_0_io_out_bits;
+  wire Queue_0_io_enq_ready;
+  wire Queue_0_io_deq_valid;
+  wire[31:0] Queue_0_io_deq_bits;
+  wire VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_1_io_in_ready;
+  wire VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_1_io_out_valid;
+  wire[31:0] VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_1_io_out_bits;
+  wire Queue_1_io_enq_ready;
+  wire Queue_1_io_deq_valid;
+  wire[31:0] Queue_1_io_deq_bits;
+  wire VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_2_io_in_ready;
+  wire VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_2_io_out_valid;
+  wire[31:0] VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_2_io_out_bits;
+
+
+  assign io_out_bits = VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_2_io_out_bits;
+  assign io_out_valid = VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_2_io_out_valid;
+  assign io_in_ready = VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_0_io_in_ready;
+  VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_0(
+       .io_in_ready( VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_0_io_in_ready ),
+       .io_in_valid( io_in_valid ),
+       .io_in_bits( io_in_bits ),
+       .io_out_ready( Queue_0_io_enq_ready ),
+       .io_out_valid( VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_0_io_out_valid ),
+       .io_out_bits( VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_0_io_out_bits )
+  );
+  Queue Queue_0(.clk(clk), .reset(reset),
+       .io_enq_ready( Queue_0_io_enq_ready ),
+       .io_enq_valid( VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_0_io_out_valid ),
+       .io_enq_bits( VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_0_io_out_bits ),
+       .io_deq_ready( VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_1_io_in_ready ),
+       .io_deq_valid( Queue_0_io_deq_valid ),
+       .io_deq_bits( Queue_0_io_deq_bits )
+       //.io_count(  )
+  );
+  VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_1(
+       .io_in_ready( VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_1_io_in_ready ),
+       .io_in_valid( Queue_0_io_deq_valid ),
+       .io_in_bits( Queue_0_io_deq_bits ),
+       .io_out_ready( Queue_1_io_enq_ready ),
+       .io_out_valid( VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_1_io_out_valid ),
+       .io_out_bits( VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_1_io_out_bits )
+  );
+  Queue Queue_1(.clk(clk), .reset(reset),
+       .io_enq_ready( Queue_1_io_enq_ready ),
+       .io_enq_valid( VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_1_io_out_valid ),
+       .io_enq_bits( VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_1_io_out_bits ),
+       .io_deq_ready( VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_2_io_in_ready ),
+       .io_deq_valid( Queue_1_io_deq_valid ),
+       .io_deq_bits( Queue_1_io_deq_bits )
+       //.io_count(  )
+  );
+  VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_2(
+       .io_in_ready( VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_2_io_in_ready ),
+       .io_in_valid( Queue_1_io_deq_valid ),
+       .io_in_bits( Queue_1_io_deq_bits ),
+       .io_out_ready( io_out_ready ),
+       .io_out_valid( VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_2_io_out_valid ),
+       .io_out_bits( VerilogMultiModule_MultiMultiFIR_2_MultiFIR_FilterSection_2_io_out_bits )
+  );
+endmodule
+
+module VerilogMultiModule_MultiMultiFIR_2(input clk, input reset,
+    output io_in_ready,
+    input  io_in_valid,
+    input [31:0] io_in_bits,
+    input  io_out_ready,
+    output io_out_valid,
+    output[31:0] io_out_bits
+);
+
+  wire m1_io_out_valid;
+  wire[31:0] m1_io_out_bits;
+  wire m2_io_in_ready;
+
+
+`ifndef SYNTHESIS
+// synthesis translate_off
+//  assign io_out_bits = {1{$random}};
+//  assign io_out_valid = {1{$random}};
+//  assign io_in_ready = {1{$random}};
+// synthesis translate_on
+`endif
+  VerilogMultiModule_MultiMultiFIR_2_MultiFIR m1(.clk(clk), .reset(reset),
+       //.io_in_ready(  )
+       //.io_in_valid(  )
+       //.io_in_bits(  )
+       .io_out_ready( m2_io_in_ready ),
+       .io_out_valid( m1_io_out_valid ),
+       .io_out_bits( m1_io_out_bits )
+  );
+`ifndef SYNTHESIS
+// synthesis translate_off
+    assign m1.io_in_valid = {1{$random}};
+    assign m1.io_in_bits = {1{$random}};
+// synthesis translate_on
+`endif
+  VerilogMultiModule_MultiMultiFIR_2_MultiFIR m2(.clk(clk), .reset(reset),
+       .io_in_ready( m2_io_in_ready ),
+       .io_in_valid( m1_io_out_valid ),
+       .io_in_bits( m1_io_out_bits )
+       //.io_out_ready(  )
+       //.io_out_valid(  )
+       //.io_out_bits(  )
+  );
+`ifndef SYNTHESIS
+// synthesis translate_off
+    assign m2.io_out_ready = {1{$random}};
+// synthesis translate_on
+`endif
+endmodule
+

--- a/src/test/scala/VerilogMultiModule.scala
+++ b/src/test/scala/VerilogMultiModule.scala
@@ -1,0 +1,96 @@
+/*
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
+ California (Regents). All Rights Reserved.  Redistribution and use in
+ source and binary forms, with or without modification, are permitted
+ provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer in the documentation and/or other materials
+      provided with the distribution.
+    * Neither the name of the Regents nor the names of its contributors
+      may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+ IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
+ ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION
+ TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ MODIFICATIONS.
+*/
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.Ignore
+
+import Chisel._
+
+
+class VerilogMultiModule extends TestSuite {
+  @Test def testVerilogMultiModule() {
+    // A class to generate multiple "filter" sections.
+    // The default is two sections.
+    // For any module with more than one section, Queues are used to interconnect sections.
+    case class MultiMultiFIR (nSections: Int = 2) extends Module {
+      case class MultiFIR (nSections: Int = 2) extends Module {
+        class FilterSection(coeffs: Array[Flo]) extends Module {
+          val io = new Bundle {
+            val in = Decoupled(Flo(INPUT)).flip
+            val out = Decoupled(Flo(OUTPUT))
+      
+          }
+          // Specify the filter function - multiply by two.
+          io.out.bits := io.in.bits * Flo(2.0)
+          // Connect the valid (output) and ready (input) signals
+          io.out.valid := io.in.valid
+          io.in.ready := io.out.ready
+        }
+      
+        val io = new Bundle {
+          val in = Decoupled(Flo(INPUT)).flip
+          val out = Decoupled(Flo(OUTPUT))
+        }
+        // Parameterized filter sections. If more than a single section,
+        //  insert queues between each section.
+        var lastin = io.in
+        require(nSections > 0, "MultiFIR: nSections must be greater than 0")
+        for (s <- 1 to nSections) {
+          val f = Module(new FilterSection(Array(Flo(1.0))))
+  //        f.name = "f" + s.toString
+          f.io.in <> lastin
+          // Do we have a following section?
+          if (s < nSections) {
+            val q = Module(new Queue(Flo(), 4))
+  //          q.name = "q" + s.toString + (s+1).toString
+            q.io.enq <> f.io.out
+            lastin = q.io.deq
+          } else {
+            io.out <> f.io.out
+          }
+        }
+      }
+      val io = new Bundle {
+        val in = Decoupled(Flo(INPUT)).flip
+        val out = Decoupled(Flo(OUTPUT))
+      }
+      val m1 = Module(new MultiFIR(nSections))
+      val m2 = Module(new MultiFIR(nSections))
+      m2.io.in <> m1.io.out
+    }
+    
+    chiselMain(Array[String]("--backend", "v",
+        "--targetDir", dir.getPath.toString()),
+        () => Module(new MultiMultiFIR(3)))
+    assertFile("VerilogMultiModule_MultiMultiFIR_2.v")
+  }
+
+}


### PR DESCRIPTION
Generate unique names for sub-modules on a per-module basis for the Verilog backend. This allows the text comparison logic in Verilog::emitChildren() to recognize common implementations.