### PR TITLE
Observations/suggestions from Doug Hogberg at Google.

### DIFF
--- a/src/main/resources/emulator_api.h
+++ b/src/main/resources/emulator_api.h
@@ -237,7 +237,7 @@ public:
 	mem_dummy() :
 		mem_api_base("error", "")
 	{}
-	string get_element(std::string index) {
+	std::string get_element(std::string index) {
 		return "error";
 	}
 
@@ -352,7 +352,7 @@ public:
 	// Errors return "error", printing a more detailed description to stderr.
 	// TODO: find a way to pass errors in-line, so transport layers other than
 	// stdin/stdout (like TCP/IP) are possible while also communicating errors.
-	std::string eval_command(string command) {
+	std::string eval_command(std::string command) {
 		std::vector<std::string> tokens = tokenize(command);
 		if (tokens.size() == 0) {
 			std::cerr << "Empty command: '" << command << "'" << std::endl;
@@ -461,7 +461,7 @@ public:
 			// OUT: true (on success), false (on failure)
 			if (!check_command_length(tokens, 2, 3)) { return ""; }
 			cerr << "poke is deprecated, use wire_poke or mem_poke" << std::endl;
-			bool success;
+			bool success = false;
 			if (tokens.size() == 3) {
 				success = get_dat_by_name(tokens[1])->set_value(tokens[2]);
 			} else if (tokens.size() == 4) {

--- a/src/main/resources/emulator_mod.h
+++ b/src/main/resources/emulator_mod.h
@@ -1712,6 +1712,7 @@ class mod_t {
     is_stale(false),
     printStream()
     {}
+  virtual ~mod_t() {}
   std::vector< mod_t* > children;
   virtual void init ( val_t rand_init=false ) { };
   virtual void clock_lo ( dat_t<1> reset ) { };


### PR DESCRIPTION
EMail of 3/12/2015, 7:30pm, Re: Chisel with Scala 2.11.4

Some nit's on the emulator*.h code:

Seen in a few places:
emulator_mod.h:1722:3: error: 'mod_t' has virtual functions but non-virtual destructor [-Werror,-Wnon-virtual-dtor]
Worked around with: -Wno-non-virtual-dtor

Should be std::string below for consistency
emulator_api.h:240:2: error: reference to 'string' is ambiguous
        string get_element(std::string index)
emulator_api.h:355:27: error: reference to 'string' is ambiguous
        std::string eval_command(string command)
Fixed locally.

Uninitialized value:
emulator_api.h:467:15: error: variable 'success' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]
                        } else if (tokens.size() == 4) {
                                   ^~~~~~~~~~~~~~~~~~
third_party/hardware/chips/chisel/current/csrc/emulator_api.h:471:8: note: uninitialized use occurs here
                        if (success) {
                            ^~~~~~~
third_party/hardware/chips/chisel/current/csrc/emulator_api.h:467:11: note: remove the 'if' if its condition is always true
                        } else if (tokens.size() == 4) {
                               ^~~~~~~~~~~~~~~~~~~~~~~~
third_party/hardware/chips/chisel/current/csrc/emulator_api.h:464:16: note: initialize the variable 'success' to silence this warning
                        bool success;
                                    ^