### PR TITLE
Fix Data width lost in Vec #384.

### DIFF
--- a/src/main/scala/SInt.scala
+++ b/src/main/scala/SInt.scala
@@ -64,7 +64,7 @@ class SInt extends Bits with Num[SInt] {
   }
 
   override def matchWidth(w: Width): Node = {
-    val this_width = this.widthW
+    val this_width = this.getWidthW()
     if (w.isKnown && this_width.isKnown) {
       val my_width = this_width.needWidth()
       val match_width = w.needWidth()


### PR DESCRIPTION
Use getWidthW() instead of widthW in SInt.matchWidth() to get the
current node's width, so if we can infer it we will.