### PR TITLE
make ChiselErrors private so clients are forced to use Chisel.error() - #393

### DIFF
--- a/src/main/scala/Backend.scala
+++ b/src/main/scala/Backend.scala
@@ -282,8 +282,8 @@ abstract class Backend extends FileSystemUtilities{
             // not symmetric and only applies to direct children
             // READ BACK INPUT -- TODO: TIGHTEN THIS UP
             !isBitsIo(input, INPUT)) {
-          ChiselErrors += new ChiselError(() => {
-            "Illegal cross module reference between " + node + " and " + input }, node.line)
+          ChiselError.error(new ChiselError(() => {
+            "Illegal cross module reference between " + node + " and " + input }, node.line))
         }
         if (input.component == null) input.component = curComp
       }

--- a/src/main/scala/ChiselError.scala
+++ b/src/main/scala/ChiselError.scala
@@ -31,13 +31,25 @@
 package Chisel
 import scala.collection.mutable.ArrayBuffer
 
+// Disable println warnings. It's what we do.
+// scalastyle:off regex
 /** This Singleton implements a log4j compatible interface.
   It is used through out the Chisel package to report errors and warnings
   detected at runtime.
   */
 object ChiselError {
   var hasErrors: Boolean = false;
-  val ChiselErrors = new ArrayBuffer[ChiselError];
+  private val ChiselErrors = new ArrayBuffer[ChiselError];
+
+  def contains(chiselError: ChiselError): Boolean = {
+    ChiselErrors.contains(chiselError)
+  }
+
+  def isEmpty: Boolean = {
+    ChiselErrors.isEmpty
+  }
+
+  def getErrorList: List[ChiselError] = ChiselErrors.toList
 
   def clear() {
     ChiselErrors.clear()
@@ -45,9 +57,14 @@ object ChiselError {
   }
 
   /** emit an error message */
-  def error(mf: => String, line: StackTraceElement) {
+  def error(chiselError: ChiselError) {
     hasErrors = true
-    ChiselErrors += new ChiselError(() => mf, line)
+    ChiselErrors += chiselError
+  }
+
+  def error(mf: => String, line: StackTraceElement) {
+    val chiselError = new ChiselError(() => mf, line)
+    error(chiselError)
   }
 
   def error(m: String) {
@@ -155,14 +172,17 @@ val errlevel: Int = 0) {
   val line = errline
   val msgFun = errmsgFun
 
-  def isError = (level == 0)
-  def isWarning = (level == 1)
+  def isError: Boolean = (level == 0)
+  def isWarning : Boolean = (level == 1)
 
   def print() {
     /* Following conventions for error formatting */
     val levelstr =
-      if (isError) ChiselError.tag("error", Console.RED)
-      else ChiselError.tag("warn", Console.YELLOW)
+      if (isError) {
+        ChiselError.tag("error", Console.RED)
+      } else {
+        ChiselError.tag("warn", Console.YELLOW)
+      }
     if( line != null ) {
       println(levelstr + " " + line.getFileName + ":" +
         line.getLineNumber + ": " + msgFun() +

--- a/src/main/scala/Module.scala
+++ b/src/main/scala/Module.scala
@@ -59,9 +59,9 @@ object Module {
     pop()
     for ((n, io) <- res.wires) {
       if (io.dir == null)
-         ChiselErrors += new ChiselError(() => {"All IO's must be ports (dir set): " + io}, io.line)
+         ChiselError.error(new ChiselError(() => {"All IO's must be ports (dir set): " + io}, io.line))
       // else if (! io.isKnownWidth)
-      //   ChiselErrors += new ChiselError(() => {"All IO's must have width set: " + io}, io.line)
+      //   ChiselError.error(new ChiselError(() => {"All IO's must have width set: " + io}, io.line))
       io.isIo = true
     }
     res
@@ -243,7 +243,7 @@ abstract class Module(var clock: Clock = null, private[Chisel] var _reset: Bool 
     p.inputs.foreach(debug _)
     for (arg <- args)
       if (arg.isInstanceOf[Aggregate])
-        ChiselErrors += new ChiselError(() => { "unable to printf aggregate argument " + arg }, arg.line)
+        ChiselError.error(new ChiselError(() => { "unable to printf aggregate argument " + arg }, arg.line))
   }
 
   def <>(src: Module) {

--- a/src/main/scala/Node.scala
+++ b/src/main/scala/Node.scala
@@ -65,8 +65,8 @@ object Node {
     } catch {
         case e: java.lang.IndexOutOfBoundsException => {
           val error = new ChiselError(() => {m + " is unconnected ("+ i + " of " + m.inputs.length + "). Ensure that it is assigned."}, m.line)
-          if (!ChiselErrors.contains(error) && !Driver.isInGetWidth) {
-            ChiselErrors += error
+          if (!ChiselError.contains(error) && !Driver.isInGetWidth) {
+            ChiselError.error(error)
           }
           Width()
        }
@@ -375,8 +375,8 @@ abstract class Node extends nameable {
     for(i <- 0 until inputs.length) {
       if(inputs(i) == null){
         val error = new ChiselError(() => {"NULL Input for " + this.getClass + " " + this + " in Module " + component}, this.line);
-        if (!ChiselErrors.contains(error)) {
-          ChiselErrors += error
+        if (!ChiselError.contains(error)) {
+          ChiselError.error(error)
         }
       }
       else if(inputs(i).isTypeNode) {

--- a/src/test/scala/ConnectTest.scala
+++ b/src/test/scala/ConnectTest.scala
@@ -279,7 +279,7 @@ class ConnectSuite extends TestSuite {
     } catch {
       case _ : Throwable => ;
     }
-    assertTrue(!ChiselError.ChiselErrors.isEmpty);
+    assertTrue(ChiselError.hasErrors);
   }
 
   @Test def testVecInput() {
@@ -351,7 +351,7 @@ class ConnectSuite extends TestSuite {
     } catch {
       case _ : Throwable => ;
     }
-    assertTrue(!ChiselError.ChiselErrors.isEmpty);
+    assertTrue(ChiselError.hasErrors);
   }
 
   /** Test Unspecified Bundle Values.

--- a/src/test/scala/DataTest.scala
+++ b/src/test/scala/DataTest.scala
@@ -203,7 +203,7 @@ class DataSuite extends TestSuite {
     } catch {
       case _ : Throwable => ;
     }
-    assertTrue(!ChiselError.ChiselErrors.isEmpty);
+    assertTrue(ChiselError.hasErrors);
   }
 
   // tests assigning to non parent's outputs
@@ -233,7 +233,7 @@ class DataSuite extends TestSuite {
     } catch {
       case _ : Throwable => ;
     }
-    assertTrue(!ChiselError.ChiselErrors.isEmpty);
+    assertTrue(ChiselError.hasErrors);
   }
 
   /** Test case derived from issue #1 reported on github.
@@ -259,7 +259,7 @@ class DataSuite extends TestSuite {
     } catch {
       case _ : Throwable => ;
     }
-    assertTrue(!ChiselError.ChiselErrors.isEmpty);
+    assertTrue(ChiselError.hasErrors);
   }
 
 

--- a/src/test/scala/ModuleTests.scala
+++ b/src/test/scala/ModuleTests.scala
@@ -61,7 +61,7 @@ class ModuleTests extends TestSuite {
     } catch {
       case e : java.lang.IllegalStateException => {}
     }
-    assertTrue(!ChiselError.ChiselErrors.isEmpty);
+    assertTrue(ChiselError.hasErrors);
   }
 
 }

--- a/src/test/scala/StdlibTest.scala
+++ b/src/test/scala/StdlibTest.scala
@@ -846,7 +846,7 @@ try {
     } catch {
       case e : java.lang.IllegalStateException => {}
     }
-    assertTrue(!ChiselError.ChiselErrors.isEmpty);
+    assertTrue(ChiselError.hasErrors);
   }
 
   /** Test for issue #384 - Data width lost in Vec

--- a/src/test/scala/VerifTest.scala
+++ b/src/test/scala/VerifTest.scala
@@ -111,7 +111,7 @@ class VerifSuite extends TestSuite {
     } catch {
       case _ : Throwable => ;
     }
-    assertTrue(!ChiselError.ChiselErrors.isEmpty);
+    assertTrue(ChiselError.hasErrors);
   }
 
   @Test def testPrintfVerilog() {

--- a/src/test/scala/ZeroWidthTest.scala
+++ b/src/test/scala/ZeroWidthTest.scala
@@ -451,7 +451,7 @@ class ZeroWidthTest extends TestSuite {
     }
 
     chiselMain(testArgs, () => Module(new ReverseNoisyWidth()))
-    assertTrue(ChiselError.ChiselErrors.isEmpty);
+    assertTrue(ChiselError.isEmpty);
   }
 
   /** Issue #335


### PR DESCRIPTION
Several clients were adding errors to ChiselError.ChiselErrors directly which unfortunately doesn't update ChiselError.hasError which is used by ChiselError.checkpoint() to determine if it should abort or not. We could have changed hasErrors to basically do a ChiselErrors.isEmpty, but the ArrauBuffer contains warnings as well so currently, hasErrors != isEmpty.