### PR TITLE
Provide chiselEnvironmentArguments() to fetch arguments from the environment.

### DIFF
--- a/src/main/scala/hcl.scala
+++ b/src/main/scala/hcl.scala
@@ -30,6 +30,7 @@
 
 package Chisel
 import ChiselError._
+import scala.util.Properties
 
 class TestIO(val format: String, val args: Seq[Data] = null)
 
@@ -158,3 +159,31 @@ class Delay extends Node {
   def assignClock(clk: Clock): Unit = { clock = clk }
 }
 
+  /** If there is an environment variable `chiselArguments`, construct an `Array[String]`
+    *  of its value split on ' ', otherwise, return a 0 length `Array[String]`
+    *  
+    *  This makes it easy to merge with command line arguments and have the latter take precedence.
+    * {{{
+    *  def main(args: Array[String]) {
+    *      val readArgs(chiselEnvironmentArguments ++ args)
+    *      ...
+    *  }
+    * }}}
+    */
+object chiselEnvironmentArguments {
+  /** The ''name'' of the environment variable containing the arguments. */
+  val chiselArgumentNameDefault = "chiselArguments"
+
+  /**
+    * @return value of environment variable `chiselArguments` split on ' ' or a 0 length Array[String]
+    *  
+    */
+  def apply(envName: String = chiselArgumentNameDefault): Array[String] = {
+    val chiselArgumentString = Properties.envOrElse(envName, "")
+    if (chiselArgumentString != "") {
+      chiselArgumentString.split(' ')
+    } else {
+      new Array[String](0)
+    }
+  }
+}

--- a/src/test/scala/TestSuite.scala
+++ b/src/test/scala/TestSuite.scala
@@ -34,7 +34,6 @@ import java.io.File
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 import scala.collection.JavaConversions
-import scala.util.Properties
 import Chisel._
 import TestSuite._
 
@@ -42,7 +41,7 @@ object TestSuite {
 
   // Should we enable some global settings?
   val partitionIslandsParameterName = "partitionIslands"
-  val partitionIslandsArguments = Properties.envOrElse(partitionIslandsParameterName, "")
+  val partitionIslandsArguments = chiselEnvironmentArguments(partitionIslandsParameterName)
 }
 
 abstract class TestSuite extends JUnitSuite {
@@ -89,9 +88,8 @@ abstract class TestSuite extends JUnitSuite {
       () => Module(ctor.newInstance(this).asInstanceOf[M])) {t}
     // If this is a test of the Cpp backend, launch it again with some Cpp specific arguments,
     //  if "partitionIslands" is defined in the environment and isn't one of the specified test arguments.
-    if (b == "c" && partitionIslandsArguments != "" && !testArgs.contains("--partitionIslands")) {
-      val cppArgs = partitionIslandsArguments.split(' ')
-      chiselMainTest(testArgs ++ cppArgs,
+    if (b == "c" && partitionIslandsArguments.size != 0 && !testArgs.contains("--partitionIslands")) {
+      chiselMainTest(partitionIslandsArguments ++ testArgs,
         () => Module(ctor.newInstance(this).asInstanceOf[M])) {t}
     }
   }


### PR DESCRIPTION
Circumvent problems with getting test arguments through the test runners by making them available through the environment.
Update TestSuite to check for partitionIslands arguments using the same mechanism.