### PR TITLE
Added Wire() no-op (support for Chisel3) and associated tests.

### DIFF
--- a/src/main/scala/ChiselUtil.scala
+++ b/src/main/scala/ChiselUtil.scala
@@ -556,3 +556,27 @@ object PriorityEncoderOH
   }
   def apply(in: Bits): UInt = encode((0 until in.getWidth).map(i => in(i)))
 }
+
+/** Wrap a Chisel data type with a `Wire`.
+  *
+  * This is a no-op in Chisel 2.2. It will be required for Chisel 3.0
+  */
+object Wire
+{
+  def apply[T <: Data](t: T = null, init: T = null): T = {
+    val mType = if (t == null) init else t
+    if(mType == null) {
+      ChiselError.error("cannot infer type of Init.")
+      UInt().asInstanceOf[T]
+    } else {
+      val x = mType.clone
+      // Should this be part of 'clone'
+      // x.component = mType.component
+      if (init != null) {
+        x assign init
+      }
+      x
+    }
+  }
+}
+

--- a/src/main/scala/Vec.scala
+++ b/src/main/scala/Vec.scala
@@ -55,6 +55,9 @@ object VecMux {
 
 object Vec {
 
+  def apply[T <: Data](gen: T, n: Int): Vec[T] = 
+    /* new */ Vec((0 until n).map(i => gen.clone))
+
   /** Returns a new *Vec* from a sequence of *Data* nodes.
     */
   def apply[T <: Data](elts: Iterable[T]): Vec[T] = {

--- a/src/main/scala/hcl.scala
+++ b/src/main/scala/hcl.scala
@@ -165,7 +165,7 @@ class Delay extends Node {
     *  This makes it easy to merge with command line arguments and have the latter take precedence.
     * {{{
     *  def main(args: Array[String]) {
-    *      val readArgs(chiselEnvironmentArguments ++ args)
+    *      val readArgs(chiselEnvironmentArguments() ++ args)
     *      ...
     *  }
     * }}}

--- a/src/test/scala/BundleWire.scala
+++ b/src/test/scala/BundleWire.scala
@@ -1,0 +1,34 @@
+//package ChiselTests
+import Chisel._
+
+class Coord extends Bundle {
+  val x = UInt(width = 32)
+  val y = UInt(width = 32)
+}
+
+class BundleWire extends Module {
+  val io = new Bundle {
+    val in   = (new Coord).asInput
+    val outs = Vec((new Coord).asOutput, 4)
+  }
+  val coords = Wire(Vec(new Coord, 4))
+  for (i <- 0 until 4) {
+    coords(i)  := io.in
+    io.outs(i) := coords(i)
+  }
+}
+
+class BundleWireTester(c: BundleWire) extends Tester(c) {
+  for (t <- 0 until 4) {
+    val test_in_x = rnd.nextInt(256)
+    val test_in_y = rnd.nextInt(256)
+    poke(c.io.in.x, test_in_x)
+    poke(c.io.in.y, test_in_y)
+    step(1)
+    for (i <- 0 until 4) {
+      expect(c.io.outs(i).x, test_in_x)
+      expect(c.io.outs(i).y, test_in_y)
+    }
+  }
+}
+

--- a/src/test/scala/ComplexAssign.scala
+++ b/src/test/scala/ComplexAssign.scala
@@ -1,0 +1,40 @@
+//package ChiselTests
+import Chisel._
+
+class Complex[T <: Data](val re: T, val im: T, dir: IODirection = OUTPUT)
+    extends Bundle /* (dir) */ {
+  override def clone: this.type = 
+    new Complex(re.clone, im.clone, dir).asInstanceOf[this.type]
+}
+
+class ComplexAssign(W: Int) extends Module {
+  val io = new Bundle {
+    val e   = /* new */ Bool(INPUT)
+    val in  = new Complex(Bits(width = W), Bits(width = W), INPUT)
+    val out = new Complex(Bits(width = W), Bits(width = W), OUTPUT)
+  }
+  when (io.e) {
+    val w = Wire(new Complex(Bits(width = W), Bits(width = W)))
+    w := io.in
+    io.out.re := w.re
+    io.out.im := w.im
+  } .otherwise {
+    io.out.re := Bits(0)
+    io.out.im := Bits(0)
+  }
+}
+
+class ComplexAssignTester(c: ComplexAssign) extends Tester(c) {
+  for (t <- 0 until 4) {
+    val test_e     = rnd.nextInt(2)
+    val test_in_re = rnd.nextInt(256)
+    val test_in_im = rnd.nextInt(256)
+
+    poke(c.io.e,     test_e)
+    poke(c.io.in.re, test_in_re)
+    poke(c.io.in.im, test_in_im)
+    step(1)
+    expect(c.io.out.re, if (test_e == 1) test_in_re else 0)
+    expect(c.io.out.im, if (test_e == 1) test_in_im else 0)
+  }
+}

--- a/src/test/scala/ConnectTestWire.scala
+++ b/src/test/scala/ConnectTestWire.scala
@@ -1,0 +1,367 @@
+/*
+ Copyright (c) 2011, 2012, 2013, 2014, 2015 The Regents of the University of
+ California (Regents). All Rights Reserved.  Redistribution and use in
+ source and binary forms, with or without modification, are permitted
+ provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer in the documentation and/or other materials
+      provided with the distribution.
+    * Neither the name of the Regents nor the names of its contributors
+      may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+ IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
+ ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION
+ TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ MODIFICATIONS.
+*/
+
+import scala.collection.mutable.ArrayBuffer
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.Ignore
+
+import Chisel._
+
+/** This testsuite checks interaction of component class
+  and runtime hierarchies.
+*/
+/** The `CWTRegStatus` class is defined at the top level so we can clone it:
+  *  automatically construct it without requiring parameters.
+  */
+class CWTRegStatus extends Bundle {
+  val im0 = UInt(width = 2)
+  val im1 = UInt(width = 2)
+}
+    
+// Generic wiring module used in following tests.
+case class GenWiring[SB <: Bundle](val newStatusInstance: () => SB) extends Module {
+  val io = new Bundle {
+    val wen   = Bool(INPUT)
+    val wdata = UInt(INPUT, 4)
+    val status = newStatusInstance().asOutput
+  }
+  val wire_status = Reg(newStatusInstance())
+  when (io.wen) {
+    wire_status := newStatusInstance().fromBits(io.wdata)
+  }
+  io.status := wire_status
+  
+  // Since we're parameterized, we need a clone method.
+  override def clone() = {
+    new GenWiring[SB](newStatusInstance).asInstanceOf[this.type]
+  }
+}
+
+class ConnectWireSuite extends TestSuite {
+  // Test out wiring to a shim made via a scala def
+  @Test def testWireShimConnections() {
+    class UsesShim extends Module {
+      val io = new DecoupledUIntIO
+      def makeShim(in: DecoupledIO[UInt]): DecoupledIO[UInt] = {
+        val out = Wire(Decoupled(UInt()))
+        out.bits := in.bits + UInt(1)
+        out.valid := in.valid
+        in.ready := out.ready
+        out
+      }
+      val s = makeShim(io.in)
+      io.out.bits := s.bits
+      io.out.valid := s.valid
+      s.ready := io.out.ready
+    }
+    class UsesShimParent extends Module {
+      val io = new DecoupledUIntIO
+      val us = Module(new UsesShim)
+      us.io.in <> io.in
+      io.out <> us.io.out
+    }
+    class ShimConnectionsTests(m: UsesShimParent) extends Tester(m) {
+      (0 until 4).map { i =>
+        poke(m.io.in.bits,   i)
+        poke(m.io.in.valid,  int(true))
+        poke(m.io.out.ready, int(true))
+        step(1)
+        expect(m.io.out.valid, int(true))
+        expect(m.io.in.ready,  int(true))
+        expect(m.io.out.bits,  i+1)
+      }
+    }
+    launchCppTester((m: UsesShimParent) => new ShimConnectionsTests(m))
+  }
+
+  /** Test failure using a Wire with no default in a when(). */
+  @Ignore @Test def testWireHookNoDefaultSpecifiedForWire() {
+    try {
+      class WireHookNoDefaultSpecifiedForWire extends Module {
+        case class WireStatus() extends Bundle {
+          val im0 = Wire(UInt(width = 2))
+          val im1 = Wire(UInt(width = 2))
+        }
+    
+        val io = new Bundle {
+          val wen   = Bool(INPUT)
+          val wdata = UInt(INPUT, 4)
+          val status = new WireStatus().asOutput
+        }
+        val subModule = new GenWiring[WireStatus](WireStatus)
+        io <> Wire(subModule.io)
+      }
+      chiselMain(Array[String]("--backend", "c", "--compile",
+        "--targetDir", dir.getPath.toString()),
+        () => Module(new WireHookNoDefaultSpecifiedForWire()))
+    } catch {
+      case _ : Throwable => ;
+    }
+    assertTrue(ChiselError.hasErrors)
+  }
+
+  /** Test failure for reassignment to Wire in a when(). */
+  @Ignore @Test def testWireHookReassignmentToWire() {
+    try {
+      class WireHookReassignmentToWire extends Module {
+        case class WireStatus() extends Bundle {
+          val im0 = Wire(init = UInt(0, 2))
+          val im1 = Wire(init = UInt(1, 2))
+        }
+    
+        val io = new Bundle {
+          val wen   = Bool(INPUT)
+          val wdata = UInt(INPUT, 4)
+          val status = new WireStatus().asOutput
+        }
+        val subModule = new GenWiring[WireStatus](WireStatus)
+        io <> Wire(subModule.io)
+      }
+      chiselMain(Array[String]("--backend", "c", "--compile", 
+        "--targetDir", dir.getPath.toString()),
+        () => Module(new WireHookReassignmentToWire()))
+    } catch {
+      case _ : Throwable => ;
+    }
+    assertTrue(ChiselError.hasErrors)
+  }
+
+  @Test def testRegisterHook() {
+    try {
+      class RegHook extends Module {
+        val io = new Bundle {
+          val wen   = Bool(INPUT)
+          val wdata = UInt(INPUT, 4)
+          val status = new CWTRegStatus().asOutput
+        }
+        val reg_status = Reg(new CWTRegStatus)
+        when (io.wen) {
+          reg_status := new CWTRegStatus().fromBits(io.wdata)
+        }
+        io.status := reg_status
+      }
+  
+      class RegisterHookTests(m: RegHook) extends Tester(m) {
+        List(1,     2,     4,     6,     8,     12,    15,   15).zip(
+        List(false, true,  true,  false, true,  false, true, false)).zip(
+        List((0,0), (0,2), (1,0), (1,0), (2,0), (2,0), (3,3), (3,3))).map {
+          case ((in, en), (im0, im1)) =>
+            poke(m.io.wdata, in)
+            poke(m.io.wen,   int(en))
+            step(1)
+            expect(m.io.status.im0, im0)
+            expect(m.io.status.im1, im1)
+        }
+      }
+      launchCppTester((m: RegHook) => new RegisterHookTests(m))
+    } catch {
+      case e : Throwable => {
+        val cause = e.getCause()
+        println("exception: %s".format(cause))
+      }
+    }
+  }
+
+  /** Test hooking-up Wires. */
+  @Ignore @Test def testWireHook() {
+    try {
+
+      class WireHook extends Module {
+        val io = new Bundle {
+          val wen   = Bool(INPUT)
+          val wdata = UInt(INPUT, 4)
+          val status = new CWTRegStatus().asOutput
+        }
+        val subModule = Module(new GenWiring[CWTRegStatus](() => new CWTRegStatus) )
+        val subModuleIOWire = Wire(subModule.io)
+        if (false) {
+          io <> Wire(subModule.io)
+        } else if (true) {
+          io <> subModule.io
+        } else {
+          subModule.io.wen := Wire(io.wen).asOutput
+          subModule.io.wdata := Wire(io.wdata).asOutput
+          io.status := Wire(subModule.io.status).asInput
+        }
+      }
+  
+  
+      class WireHookTests(m: WireHook) extends Tester(m) {
+        List(1,     2,     4,     6,     8,     12,    15,   15).zip(
+        List(false, true,  true,  false, true,  false, true, false)).zip(
+        List((0,0), (0,2), (1,0), (1,0), (2,0), (2,0), (3,3), (3,3))).map {
+          case ((in, en), (im0, im1)) =>
+            poke(m.io.wdata, in)
+            poke(m.io.wen,   int(en))
+            step(1)
+            expect(m.io.status.im0, im0)
+            expect(m.io.status.im1, im1)
+        }
+      }
+      launchCppTester((m: WireHook) => new WireHookTests(m))
+    } catch {
+      case e : Throwable => {
+        val cause = e.getCause()
+        fail("exception: %s".format(cause))
+      }
+    }
+  }
+
+  @Test def testWireVecInput() {
+    class VecInput extends Module {
+      val io = new Bundle {
+        val in = Vec.fill(2){ Wire(UInt(INPUT, 8)) }
+        val out0 = UInt(OUTPUT, 8)
+        val out1 = UInt(OUTPUT, 8)
+      }
+      io.out0 := io.in(0)
+      io.out1 := io.in(1)
+    }
+
+    class VecInputTests(c: VecInput) extends Tester(c) {
+      poke(c.io.in, Array[BigInt](0, 1))
+      step(1)
+      expect(c.io.out0, 0)
+      expect(c.io.out1, 1)
+    }
+
+    launchCppTester((m: VecInput) => new VecInputTests(m))
+  }
+
+  @Test def testVecWireOutput() {
+    class VecOutput extends Module {
+      val io = new Bundle {
+        val in0 = UInt(INPUT, 8)
+        val in1 = UInt(INPUT, 8)
+        val out = Vec.fill(2){ Wire(UInt(OUTPUT, 8)) }
+      }
+
+      io.out(0) := io.in0
+      io.out(1) := io.in1
+    }
+
+    class VecOutputTests(c: VecOutput) extends Tester(c) {
+      poke(c.io.in0, 0)
+      poke(c.io.in1, 1)
+      step(1)
+      expect(c.io.out, Array[BigInt](0, 1))
+    }
+
+    launchCppTester((m: VecOutput) => new VecOutputTests(m))
+  }
+
+  // More extensive test that submodule bindings are connected to appropriate logic
+  @Test def testWireAddBindings() {
+    class CrossingBlock extends Module {
+      val io = new Bundle {
+        val i1 = Wire(UInt(width=8)).asInput
+        val i2 = Wire(UInt(width=8)).asInput
+        val o1 = Wire(UInt(width=8)).asOutput
+        val o2 = Wire(UInt(width=8)).asOutput
+      }
+      io.o2 := io.o1 + io.i2
+      io.o1 := io.i1
+    }
+    class BindingTestInternal extends Module {
+      val io = new Bundle {
+        val in1 = Wire(UInt(width=8)).asInput
+        val in2 = Wire(UInt(width=8)).asInput
+        val in3 = Wire(UInt(width=8)).asInput
+        val in4 = Wire(UInt(width=8)).asInput
+        val out1 = Wire(UInt(width=8)).asOutput
+        val out2 = Wire(UInt(width=8)).asOutput
+        val out3 = Wire(UInt(width=8)).asOutput
+        val out4 = Wire(UInt(width=8)).asOutput
+        val out5 = Wire(UInt(width=8)).asOutput
+        val out6 = Wire(UInt(width=8)).asOutput
+        val out7 = Wire(UInt(width=8)).asOutput
+        val out8 = Wire(UInt(width=8)).asOutput
+        val out9 = Wire(UInt(width=8)).asOutput
+      }
+      val cb5 = Module(new CrossingBlock)
+      val cb4 = Module(new CrossingBlock)
+      val cb3 = Module(new CrossingBlock)
+      val cb2 = Module(new CrossingBlock)
+      val cb1 = Module(new CrossingBlock)
+
+      cb1.io.i1 := io.in1
+      cb1.io.i2 := io.in2
+      io.out1 := cb1.io.o1
+      io.out2 := cb1.io.i2
+
+      cb2.io.i1 := cb1.io.o2
+      cb2.io.i2 := io.out1
+      io.out3 := cb2.io.o1
+      io.out4 := cb2.io.o2
+
+      cb3.io.i1 := cb1.io.i1 + UInt(1)
+      cb3.io.i2 := cb2.io.i1
+      io.out5 := cb3.io.o1 + cb3.io.o2 + io.out4
+
+      cb4.io.i1 := io.in3
+      cb4.io.i2 := cb4.io.i1
+      io.out6 := cb4.io.o1
+      io.out7 := cb4.io.o2
+
+      cb5.io.i1 := io.in4
+      cb5.io.i2 := cb5.io.o1
+      io.out8   := cb5.io.o2
+
+      io.out9 := io.out7
+    }
+
+    class BindingTest extends Module {
+      val io = new Bundle {
+        val in1 = Wire(UInt(width=8)).asInput
+        val in2 = Wire(UInt(width=8)).asInput
+        val in3 = Wire(UInt(width=8)).asInput
+        val in4 = Wire(UInt(width=8)).asInput
+        val out1 = Wire(UInt(width=8)).asOutput
+        val out2 = Wire(UInt(width=8)).asOutput
+        val out3 = Wire(UInt(width=8)).asOutput
+        val out4 = Wire(UInt(width=8)).asOutput
+        val out5 = Wire(UInt(width=8)).asOutput
+        val out6 = Wire(UInt(width=8)).asOutput
+        val out7 = Wire(UInt(width=8)).asOutput
+        val out8 = Wire(UInt(width=8)).asOutput
+        val out9 = Wire(UInt(width=8)).asOutput
+      }
+      val myTest = Module(new BindingTestInternal)
+      myTest.io <> io
+    }
+
+    chiselMain(Array[String]("--backend", "v",
+      "--targetDir", dir.getPath.toString()),
+      () => Module(new BindingTest()))
+    
+    assertFile("ConnectSuite_BindingTest_1.v")
+  }
+}

--- a/src/test/scala/Outer.scala
+++ b/src/test/scala/Outer.scala
@@ -1,0 +1,32 @@
+//package ChiselTests
+import Chisel._
+
+class Inner extends Module {
+  val io = new Bundle {
+    val in  = Bits(INPUT, 8)
+    val out = Bits(OUTPUT, 8)
+  }
+  io.out := io.in + Bits(1)
+}
+
+class Outer extends Module {
+  val io = new Bundle { 
+    val in  = Bits(INPUT, 8)
+    val out = Bits(OUTPUT, 8)
+  }
+  // val c = Module(new Inner)
+  val c = Array(Module(new Inner))
+  // val w = Wire(Bits(NO_DIR, 8))
+  // w := io.in
+  c(0).io.in := io.in
+  io.out  := (c(0).io.out * Bits(2))(7,0)
+}
+
+class OuterTester(c: Outer) extends Tester(c) {
+  for (t <- 0 until 16) {
+    val test_in = rnd.nextInt(256)
+    poke(c.io.in, test_in)
+    step(1)
+    expect(c.io.out, ((test_in + 1) * 2)&255)
+  }
+}

--- a/src/test/scala/Risc.scala
+++ b/src/test/scala/Risc.scala
@@ -1,0 +1,106 @@
+//package ChiselTests
+import Chisel._
+
+class Risc extends Module {
+  val io = new Bundle {
+    val isWr   = Bool(INPUT)
+    val wrAddr = UInt(INPUT, 8)
+    val wrData = Bits(INPUT, 32)
+    val boot   = Bool(INPUT)
+    val valid  = Bool(OUTPUT)
+    val out    = Bits(OUTPUT, 32)
+  }
+  val file = Mem(Bits(width = 32), 256)
+  val code = Mem(Bits(width = 32), 256)
+  val pc   = Reg(init=UInt(0, 8))
+  
+  val add_op :: imm_op :: Nil = Enum(Bits(width = 8), 2)
+
+  val inst = code(pc)
+  val op   = inst(31,24)
+  val rci  = inst(23,16)
+  val rai  = inst(15, 8)
+  val rbi  = inst( 7, 0)
+
+  val ra = Mux(rai === Bits(0), Bits(0), file(rai))
+  val rb = Mux(rbi === Bits(0), Bits(0), file(rbi))
+  val rc = Wire(Bits(width = 32))
+
+  io.valid := Bool(false)
+  io.out   := Bits(0)
+  rc       := Bits(0)
+
+  when (io.isWr) {
+    code(io.wrAddr) := io.wrData
+  } .elsewhen (io.boot) {
+    pc := UInt(0)
+  } .otherwise {
+    switch(op) {
+      is(add_op) { rc := ra + rb }
+      is(imm_op) { rc := (rai << UInt(8)) | rbi }
+    }
+    io.out := rc
+    when (rci === UInt(255)) {
+      io.valid := Bool(true)
+    } .otherwise {
+      file(rci) := rc
+    }
+    pc := pc + UInt(1)
+  }
+}
+
+class RiscTester(c: Risc) extends Tester(c) {
+  def wr(addr: BigInt, data: BigInt)  = {
+    poke(c.io.isWr,   1)
+    poke(c.io.wrAddr, addr)
+    poke(c.io.wrData, data)
+    step(1)
+  }
+  def boot()  = {
+    poke(c.io.isWr, 0)
+    poke(c.io.boot, 1)
+    step(1)
+  }
+  def tick(isBoot: Boolean)  = {
+    if (isBoot)
+      poke(c.io.boot, 0)
+    step(1)
+  }
+  def I (op: UInt, rc: Int, ra: Int, rb: Int) = {
+    // val cr = Cat(op, UInt(rc, 8), UInt(ra, 8), UInt(rb, 8)).litValue()
+    val cr = op.litValue() << 24 | rc << 16 | ra << 8 | rb
+    println("I = " + cr)
+    cr
+  }
+
+  val app  = Array(I(c.imm_op,   1, 0, 1), // r1 <- 1
+                   I(c.add_op,   1, 1, 1), // r1 <- r1 + r1
+                   I(c.add_op,   1, 1, 1), // r1 <- r1 + r1
+                   I(c.add_op, 255, 1, 0)) // rh <- r1
+  wr(0, 0) // skip reset
+  for (addr <- 0 until app.length) 
+    wr(addr, app(addr))
+  def dump(k: Int) {
+    println("K = " + k)
+    peek(c.ra)
+    peek(c.rb)
+    peek(c.rc)
+    peek(c.io.out)
+    peek(c.pc)
+    peek(c.inst)
+    peek(c.op)
+    peek(c.rci)
+    peek(c.rai)
+    peek(c.rbi)
+    peekAt(c.file, 1)
+  }
+  boot()
+  dump(0)
+  var k = 0
+  do {
+    tick(k == 0); k += 1
+    dump(k)
+  } while (!(peek(c.io.valid) == 1 || k > 10))
+  expect(k <= 10, "TIME LIMIT")
+  expect(c.io.out, 4)
+}

--- a/src/test/scala/TestSuite.scala
+++ b/src/test/scala/TestSuite.scala
@@ -82,7 +82,7 @@ abstract class TestSuite extends JUnitSuite {
   def launchTester[M <: Module : ClassTag, T <: Tester[M]](b: String, t: M => T) {
     val ctor = implicitly[ClassTag[M]].runtimeClass.getConstructors.head
 
-    val testArgs = Array[String]("--backend", b,
+    val testArgs = chiselEnvironmentArguments() ++ Array[String]("--backend", b,
       "--targetDir", dir.getPath.toString(), "--genHarness", "--compile", "--test")
     chiselMainTest(testArgs,
       () => Module(ctor.newInstance(this).asInstanceOf[M])) {t}

--- a/src/test/scala/VecApp.scala
+++ b/src/test/scala/VecApp.scala
@@ -1,0 +1,22 @@
+//package ChiselTests
+import Chisel._
+
+class VecApp(n: Int, W: Int) extends Module {
+  val io = new Bundle {
+    val a = UInt(INPUT, n)
+    val i = Vec(Bits(INPUT, W), n)
+    // val o = Vec.fill(n){ Bits(OUTPUT, W) }
+    val d = Bits(OUTPUT, W)
+  }
+  // for (j <- 0 until n)
+  //   io.o(j) := io.i(j)
+  // val w = Wire(Vec.fill(n){ Bits(width = W) })
+  // w := io.i
+  // io.o := w
+  // io.d := w(io.a)
+  io.d := io.i(io.a)
+  // io.o := io.i
+}
+
+class VecAppTester(c: VecApp) extends Tester(c) {
+}


### PR DESCRIPTION
In order to ease migration to Chisel3, add support for Wire().
Incorporate some tests from chisel3-tests to verify functionality.