### PR TITLE
Reduce size, increase number of cpp files (Cpp Backend).

### DIFF
--- a/src/main/scala/Cpp.scala
+++ b/src/main/scala/Cpp.scala
@@ -1660,6 +1660,7 @@ class CppBackend extends Backend {
             val clockXHi = clockMethods._3
             createCppFile()
             writeCppFile(clockLo.head + clockLo.body.result + clockLo.tail)
+            createCppFile()
             writeCppFile(clockIHi.head + clockIHi.body.result)
             // Note, we tacitly assume that the clock_hi initialization and execution
             // code have effectively the same signature and tail.

--- a/src/main/scala/Driver.scala
+++ b/src/main/scala/Driver.scala
@@ -337,7 +337,7 @@ object Driver extends FileSystemUtilities{
     isSupportW0W = false
     partitionIslands = false
     lineLimitFunctions = 0
-    minimumLinesPerFile = 32768
+    minimumLinesPerFile = 10000
     shadowRegisterInObject = false
     allocateOnlyNeededShadowRegisters = false
     compileInitializationUnoptimized = false


### PR DESCRIPTION
Reduce the default minimumLinesPerFile to 10000.
Add an opportunity to create a cpp file between clock_lo() and clock_hi().