### PR TITLE
Stop suppressing compiler warnings for emulator library

### DIFF
--- a/src/main/resources/emulator_api.h
+++ b/src/main/resources/emulator_api.h
@@ -4,12 +4,6 @@
 
 #include "emulator_mod.h"
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-function"
-#pragma GCC diagnostic ignored "-Wsign-compare"
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-
 #include <string>
 #include <sstream>
 #include <map>
@@ -524,9 +518,7 @@ public:
                         for (int t = 0; t < n; t++) {
                           for (int i = 2; i < tokens.size(); i++) 
                             ss << " " << get_dat_by_name(tokens[i])->get_value();
-                          int ret = module->step(false, 1);
-                          // if (!ret)
-                          //   return "error";
+                          module->step(false, 1); // not using the int (error code) return
                         }
                         return ss.str();
 		} else if (tokens[0] == "list_wires") {
@@ -678,7 +670,5 @@ protected:
 	// Snapshot functions
 	std::map<std::string, mod_t*> snapshot_table;
 };
-
-#pragma GCC diagnostic pop
 
 #endif

--- a/src/main/resources/emulator_mod.h
+++ b/src/main/resources/emulator_mod.h
@@ -4,24 +4,6 @@
 #ifndef __IS_EMULATOR_MOD__
 #define __IS_EMULATOR_MOD__
 
-#pragma GCC diagnostic push
-#ifdef __clang__
-#pragma GCC diagnostic ignored "-Wunknown-pragmas"
-#else
-#pragma GCC diagnostic ignored "-Wpragmas"
-#endif // __clang__
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wsign-compare"
-#pragma GCC diagnostic ignored "-Wparentheses"
-#pragma GCC diagnostic ignored "-Wreturn-type"
-#pragma GCC diagnostic ignored "-Wchar-subscripts"
-#pragma GCC diagnostic ignored "-Wtype-limits"
-#pragma GCC diagnostic ignored "-Wunused-function"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wreorder"
-#pragma GCC diagnostic ignored "-Wsometimes-uninitialized"
-#pragma GCC diagnostic ignored "-pedantic"
-
 #include <assert.h>
 #include <inttypes.h>
 #include <stdio.h>
@@ -546,7 +528,7 @@ struct bit_word_funs {
 
   static void inject (val_t d[], val_t s0[], int e, int s) {
     // Opposite of extract: Assign s0 to a subfield of d.
-    const int bw = e-s+1;
+    // const int bw = e-s+1;
     val_t msk[nw];
     val_t msk_lsh[nw];
     val_t s0_lsh[nw];
@@ -1714,10 +1696,10 @@ class mod_t {
     {}
   virtual ~mod_t() {}
   std::vector< mod_t* > children;
-  virtual void init ( val_t rand_init=false ) { };
-  virtual void clock_lo ( dat_t<1> reset ) { };
-  virtual void clock_hi ( dat_t<1> reset ) { };
-  virtual int  clock ( dat_t<1> reset ) { };
+  virtual void init ( val_t rand_init=false ) = 0;
+  virtual void clock_lo ( dat_t<1> reset ) = 0;
+  virtual void clock_hi ( dat_t<1> reset ) = 0;
+  virtual int  clock ( dat_t<1> reset ) = 0;
   virtual void setClocks ( std::vector< int >& periods ) { };
 
   // Returns a clone of this object's circuit state (both registers and wires).
@@ -1797,5 +1779,4 @@ class mod_t {
     throw std::runtime_error("Assertion failed: " msg); \
 }
 
-#pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
These pragmas intentionally suppress a wide swath of compiler warnings,
which hinders debugging of issues in the file. Their presence (and broad
scope) is also a negative indicator of code quality. Removal should also
make tracking down issues related to #410 much easier as the compiler
will then properly emit warnings.