### PR TITLE
Add --assertWarn flag converting Assert to Warn

### DIFF
--- a/src/main/resources/emulator_mod.h
+++ b/src/main/resources/emulator_mod.h
@@ -1779,4 +1779,9 @@ class mod_t {
     throw std::runtime_error("Assertion failed: " msg); \
 }
 
+#define WARN(cond, msg) { \
+  if (!(cond)) \
+    printf("Assertion failed: %s\n", msg); \
+}
+
 #endif

--- a/src/main/scala/Cpp.scala
+++ b/src/main/scala/Cpp.scala
@@ -566,6 +566,7 @@ class CppBackend extends Backend {
           (if (emitRef(a.cond) == "reset" || emitRef(a.cond) == Driver.implicitReset.name) "" 
            else " || " + Driver.implicitReset.name + ".lo_word()")
         if (!Driver.isAssert) ""
+        else if (Driver.isAssertWarn) "  WARN(" + cond + ", " + CString(a.message) + ");\n"
         else "  ASSERT(" + cond + ", " + CString(a.message) + ");\n"
 
       case s: Sprintf =>

--- a/src/main/scala/Driver.scala
+++ b/src/main/scala/Driver.scala
@@ -328,6 +328,7 @@ object Driver extends FileSystemUtilities{
     isTesting = false
     testCommand = None
     isAssert = true
+    isAssertWarn = false
     isDebugMem = false
     partitionIslands = false
     lineLimitFunctions = 0
@@ -403,6 +404,7 @@ object Driver extends FileSystemUtilities{
         case "--inlineMem" => isInlineMem = true
         case "--noInlineMem" => isInlineMem = false
         case "--assert" => isAssert = true
+        case "--assertWarn" => isAssertWarn = true
         case "--noAssert" => isAssert = false
         case "--debugMem" => isDebugMem = true
         case "--partitionIslands" => partitionIslands = true
@@ -492,6 +494,7 @@ object Driver extends FileSystemUtilities{
   var isTesting = false
   var testCommand: Option[String] = None
   var isAssert = true
+  var isAssertWarn = false
   var isDebugMem = false
   var partitionIslands = false
   var lineLimitFunctions = 0


### PR DESCRIPTION
This adds a new Chisel option "--assertWarn" which changes the emitted
C++ backend to evoke more warning-like behavior. With this flag enabled,
the C++ backend uses a new "WARN" macro (which prints the assertion
message) instead of the "ASSERT" macro (which triggers an exception).
The Verilog backend is unchanged as assertions are currently printed to
stderr and won't kill a simulation.

As there are three options now, "--noAssert" takes precedence with
"--assertWarn" overriding the default-enabled "--assert". The Verilog
backend ignores "--assertWarn".

This should address #437. 