### PR TITLE
doc: No AsyncQueue anymore, replaced by AsyncFifo in ChiselUtil

### DIFF
--- a/doc/manual/manual.tex
+++ b/doc/manual/manual.tex
@@ -1352,25 +1352,31 @@ Due to metastability issues, this technique is limited to communicating one bit 
 The second and more general way to send data between domains is by using an asynchronous queue:
 
 \begin{scala}
-class AsyncQueue[T<:Data](gen: T, depth: Int, enq_clk: Clock, deq_clock: Clock)
+class AsyncFifo[T<:Data](gen: T, entries: Int, enq_clk: Clock, deq_clock: Clock)
   extends Module
 \end{scala}
 
 \noindent
-We can then get a version of signalA from clock domains clockA to clockB by specifying the standard queue parameters and the two clocks and then using the standard decoupled ready/valid signals:
+We can then get a version of signalA from clock domains clockA to clockB by
+specifying the standard queue parameters and the two clocks and then using the
+standard decoupled ready/valid signals:
 
 \begin{scala}
-val queue = new AsyncQueue(Uint(width = 32), 2, clockA, clockB)
-fifo.enq.bits := signalA
-signalB       := fifo.deq.bits
-fifo.valid    := condA
-fifo.ready    := condB
+val fifo = new AsyncFifo(Uint(width = 32), 2, clockA, clockB)
+fifo.io.enq.bits  := signalA
+signalB           := fifo.io.deq.bits
+fifo.io.enq.valid := condA
+fifo.io.deq.ready := condB
 ...
 \end{scala}
 
 \subsection{Backend Specific Multiple Clock Domains}
 
-Clock domains can be mapped to both the C++ and Verilog backends in a domain-specific manner.  For the purposes of showing how to drive a multi clock design, consider the example of hardware with two modules communicating using an AsyncQueue with each module on separate clocks: \verb+fastClock+ and \verb+slowClock+.  
+Clock domains can be mapped to both the C++ and Verilog backends in a
+domain-specific manner.  For the purposes of showing how to drive a multi
+clock design, consider the example of hardware with two modules communicating
+using an AsyncFifo with each module on separate clocks: \verb+fastClock+ and
+\verb+slowClock+.
 
 \subsubsection{C++}
 

--- a/doc/tutorial/tutorial.tex
+++ b/doc/tutorial/tutorial.tex
@@ -1934,30 +1934,36 @@ signalB := s2
 \noindent
 Due to metastability issues, this technique is limited to communicating one bit data between domains.
 
-The second and more general way to send data between domains is by using an asynchronous queue:
+The second and more general way to send data between domains is by using an asynchronous fifo:
 
 \begin{scala}
-class AsyncQueue[T<:Data]
-    (gen: T, depth: Int, enq_clk: Clock, deq_clock: Clock)
+class AsyncFifo[T<:Data]
+    (gen: T, entries: Int, enq_clk: Clock, deq_clock: Clock)
   extends Module
 \end{scala}
 
 \noindent
-When get a version of signalA from clock domains clockA to clockB by specifying the standard queue parameters and the two clocks and then using the standard decoupled ready/valid signals:
+When get a version of signalA from clock domains clockA to clockB by
+specifying the standard queue parameters and the two clocks and then using the
+standard decoupled ready/valid signals:
 
 \begin{scala}
-val queue = 
-  new AsyncQueue(Uint(width = 32), 2, clockA, clockB)
-fifo.enq.bits := signalA
-signalB       := fifo.deq.bits
-fifo.valid    := condA
-fifo.ready    := condB
+val fifo =
+  new AsyncFifo(Uint(width = 32), 2, clockA, clockB)
+fifo.io.enq.bits  := signalA
+signalB           := fifo.io.deq.bits
+fifo.io.enq.valid := condA
+fifo.io.deq.ready := condB
 ...
 \end{scala}
 
 \subsection{Backend Specific Multiple Clock Domains}
 
-Each Chisel backend requires the user to setup up and control multiple clocks in a backend specific manner.  For the purposes of showing how to drive a multi clock design, consider the example of hardware with two modules communicating using an AsyncQueue with each module on separate clocks: \verb+fastClock+ and \verb+slowClock+.  
+Each Chisel backend requires the user to setup up and control multiple clocks
+in a backend specific manner.  For the purposes of showing how to drive a
+multi clock design, consider the example of hardware with two modules
+communicating using an AsyncFifo with each module on separate clocks:
+\verb+fastClock+ and \verb+slowClock+.
 
 \subsubsection{C++}
 


### PR DESCRIPTION
I think the reference to AsyncQueue is from an old version of Chisel, because I can't found AsyncQueue in Chisel code.
I think AsyncQueue is replaced with AsyncFifo now as I can see in ChiselUtil.
Here is a patch for documentation correction.