### PR TITLE
Added Newton-Raphson Division to Fixed

### DIFF
--- a/src/main/scala/ChiselUtil.scala
+++ b/src/main/scala/ChiselUtil.scala
@@ -151,6 +151,17 @@ object ShiftRegister
       in
     }
   }
+  def apply[T <: Data](in: T, init: T, n: Int, en: Bool = Bool(true)): T =
+  {
+    // The order of tests reflects the expected use cases.
+    if (n == 1) {
+      RegEnable(in, init, en)
+    } else if (n != 0) {
+      RegNext(apply(in, init, n-1, en), init)
+    } else {
+      in
+    }
+  }
 }
 
 /** Returns the one hot encoding of the input UInt.

--- a/src/main/scala/ChiselUtil.scala
+++ b/src/main/scala/ChiselUtil.scala
@@ -140,7 +140,8 @@ object RegEnable
   */
 object ShiftRegister
 {
-  def apply[T <: Data](in: T, n: Int, en: Bool = Bool(true)): T =
+  def apply[T <: Data](in: T, n: Int) : T = apply(in, n, Bool(true))
+  def apply[T <: Data](in: T, n: Int, en: Bool) : T =
   {
     // The order of tests reflects the expected use cases.
     if (n == 1) {
@@ -151,7 +152,9 @@ object ShiftRegister
       in
     }
   }
-  def apply[T <: Data](in: T, init: T, n: Int, en: Bool = Bool(true)): T =
+  
+  def apply[T <: Data](in: T, init: T, n: Int) : T = apply(in, init, n, Bool(true))
+  def apply[T <: Data](in: T, init: T, n: Int, en: Bool) : T =
   {
     // The order of tests reflects the expected use cases.
     if (n == 1) {

--- a/src/main/scala/Fixed.scala
+++ b/src/main/scala/Fixed.scala
@@ -68,12 +68,12 @@ class Fixed(var fractionalWidth : Int = 0) extends Bits with Num[Fixed] {
         Fixed(x, this.getWidth(), this.fractionalWidth).asInstanceOf[this.type]
     }
 
-  override def cloneType: this.type = {
-    val res = Fixed(this.dir, this.getWidth(), this.fractionalWidth).asInstanceOf[this.type];
-    res
-  }
+    override def cloneType: this.type = {
+        val res = Fixed(this.dir, this.getWidth(), this.fractionalWidth).asInstanceOf[this.type];
+        res
+    }
 
-  def getFractionalWidth : Int = this.fractionalWidth
+    def getFractionalWidth : Int = this.fractionalWidth
 
     def checkAligned(b : Fixed) = if(this.fractionalWidth != b.fractionalWidth) ChiselError.error(this.fractionalWidth + " Fractional Bits does not match " + b.fractionalWidth)
 
@@ -82,6 +82,8 @@ class Fixed(var fractionalWidth : Int = 0) extends Bits with Num[Fixed] {
         res.fractionalWidth = fractionalWidth
         res
     }
+
+    def toDouble(x : BigInt, fracWidth : Int) : Double = x.toDouble/scala.math.pow(2, fracWidth)
 
     // Order Operators
     def > (b : Fixed) : Bool = {
@@ -103,7 +105,7 @@ class Fixed(var fractionalWidth : Int = 0) extends Bits with Num[Fixed] {
         checkAligned(b)
         this.toSInt <= b.toSInt
     }
-    
+
     def === (b : Fixed) : Bool = {
         checkAligned(b)
         this.toSInt === b.toSInt
@@ -132,7 +134,7 @@ class Fixed(var fractionalWidth : Int = 0) extends Bits with Num[Fixed] {
         val res = temp + ((temp & UInt(1)<<UInt(this.fractionalWidth-1))<<UInt(1))
         fromSInt(res >> UInt(this.fractionalWidth))
     }
-    
+
     def * (b : Fixed) : Fixed = {
         checkAligned(b)
         val temp = this.toSInt * b.toSInt
@@ -142,6 +144,13 @@ class Fixed(var fractionalWidth : Int = 0) extends Bits with Num[Fixed] {
     def / (b : Fixed) : Fixed = {
         checkAligned(b)
         fromSInt((this.toSInt << UInt(this.fractionalWidth)) / b.toSInt)
+    }
+
+    def /& (b : Fixed) : Fixed = {
+        checkAligned(b)
+        // Need Look up table
+        val lookUp = (1 until scala.math.pow(2, this.getWidth - this.fractionalWidth).toInt).map(i => 1/toDouble(BigInt(i), 1))
+        this / b
     }
 
     def % (b : Fixed) : Fixed = (this / b) & Fill(this.fractionalWidth, UInt(1))

--- a/src/main/scala/Fixed.scala
+++ b/src/main/scala/Fixed.scala
@@ -144,8 +144,5 @@ class Fixed(var fractionalWidth : Int = 0) extends Bits with Num[Fixed] {
         fromSInt((this.toSInt << UInt(this.fractionalWidth)) / b.toSInt)
     }
 
-    def % (b : Fixed) : Fixed = {
-      ChiselError.error("% currently not supported")
-      Fixed(0, this.getWidth, this.fractionalWidth)
-    }
+    def % (b : Fixed) : Fixed = (this / b) & Fill(this.fractionalWidth, UInt(1))
 }

--- a/src/main/scala/Fixed.scala
+++ b/src/main/scala/Fixed.scala
@@ -68,7 +68,7 @@ class Fixed(var fractionalWidth : Int = 0) extends Bits with Num[Fixed] {
         Fixed(x, this.getWidth(), this.fractionalWidth).asInstanceOf[this.type]
     }
 
-  override def clone: this.type = {
+  override def cloneType: this.type = {
     val res = Fixed(this.dir, this.getWidth(), this.fractionalWidth).asInstanceOf[this.type];
     res
   }
@@ -142,5 +142,10 @@ class Fixed(var fractionalWidth : Int = 0) extends Bits with Num[Fixed] {
     def / (b : Fixed) : Fixed = {
         checkAligned(b)
         fromSInt((this.toSInt << UInt(this.fractionalWidth)) / b.toSInt)
+    }
+
+    def % (b : Fixed) : Fixed = {
+      ChiselError.error("% currently not supported")
+      Fixed(0, this.getWidth, this.fractionalWidth)
     }
 }

--- a/src/main/scala/Fixed.scala
+++ b/src/main/scala/Fixed.scala
@@ -1,0 +1,144 @@
+/*
+ Copyright (c) 2011, 2012, 2013, 2014 The University of Sydney.
+ All Rights Reserved.  Redistribution and use in source and 
+ binary forms, with or without modification, are permitted
+ provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer in the documentation and/or other materials
+      provided with the distribution.
+    * Neither the name of the Regents nor the names of its contributors
+      may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+ IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
+ ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION
+ TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ MODIFICATIONS.
+*/
+
+package Chisel
+
+import Node._
+import ChiselError._
+
+object Fixed {
+    def toFixed(x : Double, fracWidth : Int) : BigInt = BigInt(scala.math.round(x*scala.math.pow(2, fracWidth)))
+    def toFixed(x : Float, fracWidth : Int) : BigInt = BigInt(scala.math.round(x*scala.math.pow(2, fracWidth)))
+    def toFixed(x : Int, fracWidth : Int) : BigInt = BigInt(scala.math.round(x*scala.math.pow(2, fracWidth)))
+
+    def apply(x : Int, width : Int, fracWidth : Int) : Fixed = apply(toFixed(x, fracWidth), width, fracWidth)
+    def apply(x : Float, width : Int, fracWidth : Int) : Fixed = apply(toFixed(x, fracWidth), width, fracWidth)
+    def apply(x : Double, width : Int, fracWidth : Int) : Fixed = apply(toFixed(x, fracWidth), width, fracWidth)
+    def apply(x : BigInt, width : Int, fracWidth : Int) : Fixed =  { 
+      val res = Lit(x, width){Fixed()}
+      res.fractionalWidth = fracWidth
+      res
+    }
+
+    def apply(dir : IODirection = null, width : Int = -1, fracWidth : Int = -1) : Fixed = {
+        val res = new Fixed(fracWidth);
+        res.create(dir, width)
+        res
+    }
+}
+
+class Fixed(var fractionalWidth : Int = 0) extends Bits with Num[Fixed] {
+    type T = Fixed
+
+    /* Fixed Factory Method */
+    override def fromNode(n : Node): this.type = {
+        val res = Fixed(OUTPUT).asTypeFor(n).asInstanceOf[this.type]
+        res.fractionalWidth = this.fractionalWidth
+        res
+    }
+
+    override def fromInt(x : Int) : this.type = {
+        Fixed(x, this.getWidth(), this.fractionalWidth).asInstanceOf[this.type]
+    }
+
+  override def clone: this.type = {
+    val res = Fixed(this.dir, this.getWidth(), this.fractionalWidth).asInstanceOf[this.type];
+    res
+  }
+
+    def checkAligned(b : Fixed) = if(this.fractionalWidth != b.fractionalWidth) ChiselError.error(this.fractionalWidth + " Fractional Bits does not match " + b.fractionalWidth)
+
+    def fromSInt(s : SInt) : Fixed = {
+        val res = chiselCast(s){Fixed()}
+        res.fractionalWidth = fractionalWidth
+        res
+    }
+
+    // Order Operators
+    def > (b : Fixed) : Bool = {
+        checkAligned(b)
+        this.toSInt > b.toSInt
+    }
+
+    def < (b : Fixed) : Bool = {
+        checkAligned(b)
+        this.toSInt < b.toSInt
+    }
+
+    def >= (b : Fixed) : Bool = {
+        checkAligned(b)
+        this.toSInt >= b.toSInt
+    }
+
+    def <= (b : Fixed) : Bool = {
+        checkAligned(b)
+        this.toSInt <= b.toSInt
+    }
+
+    def >> (b : UInt) : Fixed = {
+        fromSInt(this.toSInt >> b)
+    }
+
+    // Arithmetic Operators
+    def unary_-() : Fixed = Fixed(0, this.needWidth(), this.fractionalWidth) - this
+
+    def + (b : Fixed) : Fixed = {
+        checkAligned(b)
+        fromSInt(this.toSInt + b.toSInt)
+    }
+
+    def - (b : Fixed) : Fixed = {
+        checkAligned(b)
+        fromSInt(this.toSInt - b.toSInt)
+    }
+
+    def *& (b : Fixed) : Fixed ={
+        checkAligned(b)
+        val temp = this.toSInt * b.toSInt
+        val res = temp + ((temp & UInt(1)<<UInt(this.fractionalWidth-1))<<UInt(1))
+        fromSInt(res >> UInt(this.fractionalWidth))
+    }
+    
+    def * (b : Fixed) : Fixed ={
+        checkAligned(b)
+        val temp = this.toSInt * b.toSInt
+        fromSInt(temp >> UInt(this.fractionalWidth))
+    }
+
+    def / (b : Fixed) : Fixed = {
+        checkAligned(b)
+        fromSInt((this.toSInt << UInt(this.fractionalWidth)) / b.toSInt)
+    }
+
+    def % (b : Fixed) : Fixed = {
+        checkAligned(b)
+        fromSInt(this.toSInt % b.toSInt)
+    }
+}

--- a/src/main/scala/Fixed.scala
+++ b/src/main/scala/Fixed.scala
@@ -142,13 +142,13 @@ class Fixed(var fractionalWidth : Int = 0) extends Bits with Num[Fixed] {
     }
 
 
-    /* This is the Newton-Rhapson APPROXIMATE division algorithm
+    /* This is the Newton-Raphson APPROXIMATE division algorithm
      * Please test to make sure that the method is accurate enough for your application
      */
 
     def toDouble(x : BigInt, fracWidth : Int) : Double = x.toDouble/scala.math.pow(2, fracWidth)
 
-    // Newton-Rhapson to find 1/x - x_(t+1) = x_t(2 - a*x_t)
+    // Newton-Raphson to find 1/x - x_(t+1) = x_t(2 - a*x_t)
     def performNR(in : Fixed, xt : Fixed) : Fixed = xt*(Fixed(2.0, in.getWidth, in.fractionalWidth) - in*xt)
 
     def tailNR(in : Fixed, xt : Fixed, it : Int, pipeline : Boolean) : Fixed = {
@@ -158,7 +158,7 @@ class Fixed(var fractionalWidth : Int = 0) extends Bits with Num[Fixed] {
       if (it == 0) xtn else tailNR(in, xtn, it - 1, pipeline)
     }
 
-    /* Different methods for calling the Newton-Rhapson Division
+    /* Different methods for calling the Newton-Raphson Division
      * By default, pipelining is turned off, the resolution of the lookup table is set of 1/4 of the fractionalWidth length
      * and the number of NR iterations is 4.
      */

--- a/src/main/scala/Fixed.scala
+++ b/src/main/scala/Fixed.scala
@@ -73,6 +73,8 @@ class Fixed(var fractionalWidth : Int = 0) extends Bits with Num[Fixed] {
     res
   }
 
+  def getFractionalWidth : Int = this.fractionalWidth
+
     def checkAligned(b : Fixed) = if(this.fractionalWidth != b.fractionalWidth) ChiselError.error(this.fractionalWidth + " Fractional Bits does not match " + b.fractionalWidth)
 
     def fromSInt(s : SInt) : Fixed = {
@@ -101,13 +103,18 @@ class Fixed(var fractionalWidth : Int = 0) extends Bits with Num[Fixed] {
         checkAligned(b)
         this.toSInt <= b.toSInt
     }
+    
+    def === (b : Fixed) : Bool = {
+        checkAligned(b)
+        this.toSInt === b.toSInt
+    }
 
     def >> (b : UInt) : Fixed = {
         fromSInt(this.toSInt >> b)
     }
 
     // Arithmetic Operators
-    def unary_-() : Fixed = Fixed(0, this.needWidth(), this.fractionalWidth) - this
+    def unary_-() : Fixed = Fixed(0, this.getWidth(), this.fractionalWidth) - this
 
     def + (b : Fixed) : Fixed = {
         checkAligned(b)

--- a/src/main/scala/Fixed.scala
+++ b/src/main/scala/Fixed.scala
@@ -126,14 +126,14 @@ class Fixed(var fractionalWidth : Int = 0) extends Bits with Num[Fixed] {
         fromSInt(this.toSInt - b.toSInt)
     }
 
-    def *& (b : Fixed) : Fixed ={
+    def *& (b : Fixed) : Fixed = {
         checkAligned(b)
         val temp = this.toSInt * b.toSInt
         val res = temp + ((temp & UInt(1)<<UInt(this.fractionalWidth-1))<<UInt(1))
         fromSInt(res >> UInt(this.fractionalWidth))
     }
     
-    def * (b : Fixed) : Fixed ={
+    def * (b : Fixed) : Fixed = {
         checkAligned(b)
         val temp = this.toSInt * b.toSInt
         fromSInt(temp >> UInt(this.fractionalWidth))
@@ -142,10 +142,5 @@ class Fixed(var fractionalWidth : Int = 0) extends Bits with Num[Fixed] {
     def / (b : Fixed) : Fixed = {
         checkAligned(b)
         fromSInt((this.toSInt << UInt(this.fractionalWidth)) / b.toSInt)
-    }
-
-    def % (b : Fixed) : Fixed = {
-        checkAligned(b)
-        fromSInt(this.toSInt % b.toSInt)
     }
 }

--- a/src/main/scala/Fixed.scala
+++ b/src/main/scala/Fixed.scala
@@ -26,6 +26,8 @@
  ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION
  TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
  MODIFICATIONS.
+
+ Author : Duncan Moss (http://github.com/djmmoss)
 */
 
 package Chisel
@@ -60,30 +62,23 @@ class Fixed(var fractionalWidth : Int = 0) extends Bits with Num[Fixed] {
     /* Fixed Factory Method */
     override def fromNode(n : Node): this.type = {
         val res = Fixed(OUTPUT).asTypeFor(n).asInstanceOf[this.type]
-        res.fractionalWidth = this.fractionalWidth
+        res.fractionalWidth = this.getFractionalWidth()
         res
     }
 
-    override def fromInt(x : Int) : this.type = {
-        Fixed(x, this.getWidth(), this.fractionalWidth).asInstanceOf[this.type]
-    }
+    override def fromInt(x : Int) : this.type = Fixed(x, this.getWidth(), this.getFractionalWidth()).asInstanceOf[this.type]
 
-    override def cloneType: this.type = {
-        val res = Fixed(this.dir, this.getWidth(), this.fractionalWidth).asInstanceOf[this.type];
-        res
-    }
+    override def cloneType: this.type = Fixed(this.dir, this.getWidth(), this.getFractionalWidth()).asInstanceOf[this.type];
 
-    def getFractionalWidth : Int = this.fractionalWidth
+    def getFractionalWidth()() : Int = this.fractionalWidth
 
-    def checkAligned(b : Fixed) = if(this.fractionalWidth != b.fractionalWidth) ChiselError.error(this.fractionalWidth + " Fractional Bits does not match " + b.fractionalWidth)
+    def checkAligned(b : Fixed) = if(this.getFractionalWidth() != b.getFractionalWidth()) ChiselError.error(this.getFractionalWidth() + " Fractional Bits does not match " + b.getFractionalWidth())
 
     def fromSInt(s : SInt) : Fixed = {
         val res = chiselCast(s){Fixed()}
-        res.fractionalWidth = fractionalWidth
+        res.fractionalWidth = this.getFractionalWidth()
         res
     }
-
-    def toDouble(x : BigInt, fracWidth : Int) : Double = x.toDouble/scala.math.pow(2, fracWidth)
 
     // Order Operators
     def > (b : Fixed) : Bool = {
@@ -116,7 +111,7 @@ class Fixed(var fractionalWidth : Int = 0) extends Bits with Num[Fixed] {
     }
 
     // Arithmetic Operators
-    def unary_-() : Fixed = Fixed(0, this.getWidth(), this.fractionalWidth) - this
+    def unary_-() : Fixed = Fixed(0, this.getWidth(), this.getFractionalWidth()) - this
 
     def + (b : Fixed) : Fixed = {
         checkAligned(b)
@@ -131,47 +126,61 @@ class Fixed(var fractionalWidth : Int = 0) extends Bits with Num[Fixed] {
     def *& (b : Fixed) : Fixed = {
         checkAligned(b)
         val temp = this.toSInt * b.toSInt
-        val res = temp + ((temp & UInt(1)<<UInt(this.fractionalWidth-1))<<UInt(1))
-        fromSInt(res >> UInt(this.fractionalWidth))
+        val res = temp + ((temp & UInt(1)<<UInt(this.getFractionalWidth()-1))<<UInt(1))
+        fromSInt(res >> UInt(this.getFractionalWidth()))
     }
 
     def * (b : Fixed) : Fixed = {
         checkAligned(b)
         val temp = this.toSInt * b.toSInt
-        fromSInt(temp >> UInt(this.fractionalWidth))
+        fromSInt(temp >> UInt(this.getFractionalWidth()))
     }
 
     def / (b : Fixed) : Fixed = {
         checkAligned(b)
-        fromSInt((this.toSInt << UInt(this.fractionalWidth)) / b.toSInt)
+        fromSInt((this.toSInt << UInt(this.getFractionalWidth())) / b.toSInt)
     }
 
+
+    /* This is the Newton-Rhapson APPROXIMATE division algorithm
+     * Please test to make sure that the method is accurate enough for your application
+     */
+
+    def toDouble(x : BigInt, fracWidth : Int) : Double = x.toDouble/scala.math.pow(2, fracWidth)
+
     // Newton-Rhapson to find 1/x - x_(t+1) = x_t(2 - a*x_t)
-    def performNR(in : Fixed, xt : Fixed) : Fixed = xt*(Fixed(2, in.getWidth, in.fractionalWidth) - in*xt)
+    def performNR(in : Fixed, xt : Fixed) : Fixed = xt*(Fixed(2.0, in.getWidth, in.fractionalWidth) - in*xt)
 
     def tailNR(in : Fixed, xt : Fixed, it : Int, pipeline : Boolean) : Fixed = {
       val nxt = performNR(in, xt)
+      // Optional Pipeline Register
       val xtn = if (pipeline) Reg(init=Fixed(0, in.getWidth, in.fractionalWidth), next=nxt) else nxt
-      if (it == 0) nxt else tailNR(in, xtn, it - 1, pipeline)
+      if (it == 0) xtn else tailNR(in, xtn, it - 1, pipeline)
     }
 
-    def /& (b : Fixed) : Fixed = this /& (b, false, b.fractionalWidth/4, 4)
-    def /& (b : Fixed, pipeline : Boolean) : Fixed = this /& (b, pipeline, b.fractionalWidth/4, 4)
-    def /& (b : Fixed, numNR :  Int) : Fixed = this /& (b, false, b.fractionalWidth/4, numNR)
+    /* Different methods for calling the Newton-Rhapson Division
+     * By default, pipelining is turned off, the resolution of the lookup table is set of 1/4 of the fractionalWidth length
+     * and the number of NR iterations is 4.
+     */
+    def /& (b : Fixed) : Fixed = this /& (b, false, b.getFractionalWidth()/4, 4)
+    def /& (b : Fixed, pipeline : Boolean) : Fixed = this /& (b, pipeline, b.getFractionalWidth()/4, 4)
+    def /& (b : Fixed, numNR :  Int) : Fixed = this /& (b, false, b.getFractionalWidth()/4, numNR)
     def /& (b : Fixed, lookUpPrecision : Int, numNR : Int) : Fixed = this /& (b, false, lookUpPrecision, numNR)
 
     def /& (b : Fixed, pipeline : Boolean, lookUpPrecision : Int, numNR : Int) = {
-        checkAligned(b)
+      checkAligned(b)
 
-        val lookUp = (0 until scala.math.pow(2, b.getWidth - b.fractionalWidth + lookUpPrecision).toInt).map(i => if (i == 0) Fixed(0, b.getWidth, b.fractionalWidth) else Fixed(1/toDouble(BigInt(i), 1 + lookUpPrecision), b.getWidth, b.fractionalWidth))
-        // Put lookUp into ROM
-        val lookUpTable = Vec(lookUp)
+      // This constructs the lookup table of approximate 1/b
+      val lookUp = (0 until scala.math.pow(2, b.getWidth - b.getFractionalWidth() + lookUpPrecision + 1).toInt).map(i => if (i == 0) Fixed(0, b.getWidth, b.getFractionalWidth()) else Fixed(1.0/toDouble(BigInt(i), 1 + lookUpPrecision), b.getWidth, b.getFractionalWidth()))
 
-        val lp = b(b.getWidth - 1, b.fractionalWidth - 1 - lookUpPrecision)
-        val x0 = lookUpTable(lp)
-        val repb = tailNR(b, x0, numNR, pipeline)
-        this * repb
+      // Lits in a Vec are automatically placed into a ROM
+      val lookUpTable = Vec(lookUp)
+
+      val lp = b(b.getWidth - 1, b.getFractionalWidth() - 1 - lookUpPrecision)
+      val x0 = lookUpTable(lp)
+      val repb = tailNR(b, x0, numNR, pipeline)
+      this * repb
     }
 
-    def % (b : Fixed) : Fixed = (this / b) & Fill(this.fractionalWidth, UInt(1))
+    def % (b : Fixed) : Fixed = (this / b) & Fill(this.getFractionalWidth(), UInt(1))
 }

--- a/src/test/scala/FixedTest.scala
+++ b/src/test/scala/FixedTest.scala
@@ -423,4 +423,42 @@ class FixedSuite extends TestSuite {
 
     launchCppTester((c: FixedVec2) => new FixedVec2Tests(c))
   }
+  
+  @Test def testFixedMod() {
+    class FixedMod extends Module {
+      val io = new Bundle {
+        val a = Fixed(INPUT, 32, 16)
+        val b = Fixed(INPUT, 32, 16)
+        val c = Fixed(OUTPUT, 32, 16)
+      }
+      io.c := io.a % io.b
+    }
+
+    class FixedModTests(c : FixedMod) extends Tester(c) {
+      val trials = 10
+      val r = scala.util.Random
+
+      for (i <- 0 until trials) {
+
+        // For the testing find two numbers that we also give a number that is representable in fixed point
+        var inA = BigInt(r.nextInt(1 << 30))
+        var inB = BigInt(r.nextInt(1 << 30))
+        var doubleA = toDouble(inA, 16)
+        var doubleB = toDouble(inB, 16)
+        while(  scala.math.abs(toDouble(toFixedT(doubleA / doubleB, 16), 16) - doubleA/doubleB) > scala.math.pow(2, -17)) {
+          inA = BigInt(r.nextInt(1 << 30))
+          inB = BigInt(r.nextInt(1 << 30))
+          doubleA = toDouble(inA, 16)
+          doubleB = toDouble(inB, 16)
+        }
+        poke(c.io.a, inA)
+        poke(c.io.b, inB)
+        val div = toDouble(inA, 16) / toDouble(inB, 16)
+        val mod = div - div.toInt.toDouble
+        expect(c.io.c, toFixedT(mod, 16))
+      }
+    }
+
+    launchCppTester((c: FixedMod) => new FixedModTests(c))
+  }
 }

--- a/src/test/scala/FixedTest.scala
+++ b/src/test/scala/FixedTest.scala
@@ -1,0 +1,426 @@
+/*
+ Copyright (c) 2011, 2012, 2013, 2014 The Regents of the University of
+ California (Regents). All Rights Reserved.  Redistribution and use in
+ source and binary forms, with or without modification, are permitted
+ provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer in the documentation and/or other materials
+      provided with the distribution.
+    * Neither the name of the Regents nor the names of its contributors
+      may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+ IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
+ ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION
+ TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ MODIFICATIONS.
+*/
+
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.ListBuffer
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.Ignore
+
+
+import Chisel._
+
+
+/** This testsuite checks all methods in the Bits class.
+*/
+class FixedSuite extends TestSuite {
+
+  def toFixedT(x : Double, fracWidth : Int) : BigInt = BigInt((x*scala.math.pow(2, fracWidth)).toInt)
+  def toFixed(x : Double, fracWidth : Int) : BigInt = BigInt(scala.math.round(x*scala.math.pow(2, fracWidth)))
+  def toDouble(x : BigInt, fracWidth : Int) : Double = x.toDouble/scala.math.pow(2, fracWidth)
+
+  @Test def testConversion() {
+    val r = scala.util.Random
+    val in = BigInt(r.nextInt(1 << 30))
+    assertTrue(toFixed(toDouble(in, 16), 16) == in)
+  }
+
+  /** Extract a bit from a constant at a fixed position */
+  @Test def testFixedConstructor() {
+    val res = Fixed(0, 16, 8)
+    assertTrue( res.getWidth == 16 )
+    assertTrue( res.getFractionalWidth == 8 )
+  }
+
+  @Test def testFixedEqual() {
+    class FixedEqual extends Module {
+      val io = new Bundle {
+        val a = Fixed(INPUT, 32, 16)
+        val b = Fixed(INPUT, 32, 16)
+        val c = Bool(OUTPUT)
+      }
+      io.c := io.a === io.b
+    }
+
+    class FixedEqualTests(c : FixedEqual) extends Tester(c) {
+      val trials = 10
+      val r = scala.util.Random
+
+      for (i <- 0 until trials) {
+        val inA = BigInt(r.nextInt(1 << 30))
+        val inB = if (i%2 == 0) inA else BigInt(r.nextInt(1 << 30))
+        poke(c.io.a, inA)
+        poke(c.io.b, inB)
+        expect(c.io.c, Bool(inA == inB).litValue())
+      }
+    }
+
+    launchCppTester((c: FixedEqual) => new FixedEqualTests(c))
+  }
+
+  @Test def testFixedAdd() {
+    class FixedAdd extends Module {
+      val io = new Bundle {
+        val a = Fixed(INPUT, 32, 16)
+        val b = Fixed(INPUT, 32, 16)
+        val c = Fixed(OUTPUT, 32, 16)
+      }
+      io.c := io.a + io.b
+    }
+
+    class FixedAddTests(c : FixedAdd) extends Tester(c) {
+      val trials = 10
+      val r = scala.util.Random
+
+      for (i <- 0 until trials) {
+        val inA = BigInt(r.nextInt(1 << 30))
+        val inB = BigInt(r.nextInt(1 << 30))
+        poke(c.io.a, inA)
+        poke(c.io.b, inB)
+        expect(c.io.c, toFixed(toDouble(inA, 16) + toDouble(inB, 16), 16))
+      }
+    }
+
+    launchCppTester((c: FixedAdd) => new FixedAddTests(c))
+  }
+
+  @Test def testFixedSub() {
+    class FixedSub extends Module {
+      val io = new Bundle {
+        val a = Fixed(INPUT, 32, 16)
+        val b = Fixed(INPUT, 32, 16)
+        val c = Fixed(OUTPUT, 32, 16)
+      }
+      io.c := io.a - io.b
+    }
+
+    class FixedSubTests(c : FixedSub) extends Tester(c) {
+      val trials = 10
+      val r = scala.util.Random
+
+      for (i <- 0 until trials) {
+        val inA = BigInt(r.nextInt(1 << 30))
+        val inB = BigInt(r.nextInt(1 << 30))
+        poke(c.io.a, inA)
+        poke(c.io.b, inB)
+        expect(c.io.c, toFixed(toDouble(inA, 16) - toDouble(inB, 16), 16))
+      }
+    }
+
+    launchCppTester((c: FixedSub) => new FixedSubTests(c))
+  }
+  
+  @Test def testFixedReg() {
+    class FixedReg extends Module {
+      val io = new Bundle {
+        val a = Fixed(INPUT, 32, 16)
+        val c = Fixed(OUTPUT, 32, 16)
+      }
+      io.c := Reg(init=Fixed(0, 32, 16), next=io.a)
+    }
+
+    class FixedRegTests(c : FixedReg) extends Tester(c) {
+      val trials = 10
+      val r = scala.util.Random
+
+      for (i <- 0 until trials) {
+        val inA = BigInt(r.nextInt(1 << 30))
+        poke(c.io.a, inA)
+        step(1)
+        expect(c.io.c, inA)
+      }
+    }
+
+    launchCppTester((c: FixedReg) => new FixedRegTests(c))
+  }
+
+  @Test def testFixedUnary() {
+    class FixedUnary extends Module {
+      val io = new Bundle {
+        val a = Fixed(INPUT, 32, 16)
+        val c = Fixed(OUTPUT, 32, 16)
+      }
+      io.c := -io.a
+    }
+
+    class FixedUnaryTests(c : FixedUnary) extends Tester(c) {
+      val trials = 10
+      val r = scala.util.Random
+
+      for (i <- 0 until trials) {
+        val inA = BigInt(r.nextInt(1 << 30))
+        poke(c.io.a, inA)
+        expect(c.io.c, -inA)
+      }
+    }
+
+    launchCppTester((c: FixedUnary) => new FixedUnaryTests(c))
+  }
+  
+  @Test def testFixedCompare() {
+    class FixedCompare extends Module {
+      val io = new Bundle {
+        val a = Fixed(INPUT, 32, 16)
+        val b = Fixed(INPUT, 32, 16)
+        val gt = Bool(OUTPUT)
+        val lt = Bool(OUTPUT)
+        val gte = Bool(OUTPUT)
+        val lte = Bool(OUTPUT)
+      }
+      io.gt := io.a > io.b
+      io.lt := io.a < io.b
+      io.gte := io.a >= io.b
+      io.lte := io.a <= io.b
+    }
+
+    class FixedCompareTests(c : FixedCompare) extends Tester(c) {
+      val trials = 10
+      val r = scala.util.Random
+
+      for (i <- 0 until trials) {
+        val inA = BigInt(r.nextInt(1 << 30))
+        val inB = BigInt(r.nextInt(1 << 30))
+        poke(c.io.a, inA)
+        poke(c.io.b, inB)
+        expect(c.io.gt, Bool(inA > inB).litValue())
+        expect(c.io.lt, Bool(inA < inB).litValue())
+        expect(c.io.gte, Bool(inA >= inB).litValue())
+        expect(c.io.lte, Bool(inA <= inB).litValue()) 
+      }
+    }
+
+    launchCppTester((c: FixedCompare) => new FixedCompareTests(c))
+  }
+  
+  @Test def testFixedDiv() {
+    class FixedDiv extends Module {
+      val io = new Bundle {
+        val a = Fixed(INPUT, 32, 16)
+        val b = Fixed(INPUT, 32, 16)
+        val c = Fixed(OUTPUT, 32, 16)
+      }
+      io.c := io.a / io.b
+    }
+
+    class FixedDivTests(c : FixedDiv) extends Tester(c) {
+      val trials = 10
+      val r = scala.util.Random
+
+      for (i <- 0 until trials) {
+
+        // For the testing find two numbers that we also give a number that is representable in fixed point
+        var inA = BigInt(r.nextInt(1 << 30))
+        var inB = BigInt(r.nextInt(1 << 30))
+        var doubleA = toDouble(inA, 16)
+        var doubleB = toDouble(inB, 16)
+        while(  scala.math.abs(toDouble(toFixedT(doubleA / doubleB, 16), 16) - doubleA/doubleB) > scala.math.pow(2, -17)) {
+          inA = BigInt(r.nextInt(1 << 30))
+          inB = BigInt(r.nextInt(1 << 30))
+          doubleA = toDouble(inA, 16)
+          doubleB = toDouble(inB, 16)
+        }
+        poke(c.io.a, inA)
+        poke(c.io.b, inB)
+        expect(c.io.c, toFixedT(toDouble(inA, 16) / toDouble(inB, 16), 16))
+      }
+    }
+
+    launchCppTester((c: FixedDiv) => new FixedDivTests(c))
+  }
+  
+  @Test def testFixedMulT() {
+    class FixedMulT extends Module {
+      val io = new Bundle {
+        val a = Fixed(INPUT, 32, 16)
+        val b = Fixed(INPUT, 32, 16)
+        val c = Fixed(OUTPUT, 32, 16)
+      }
+      io.c := io.a * io.b
+    }
+
+    class FixedMulTTests(c : FixedMulT) extends Tester(c) {
+      val trials = 10
+      val r = scala.util.Random
+
+      for (i <- 0 until trials) {
+        val inA = BigInt(r.nextInt(1 << 15))
+        val inB = BigInt(r.nextInt(1 << 15))
+        poke(c.io.a, inA)
+        poke(c.io.b, inB)
+        expect(c.io.c, toFixedT(toDouble(inA, 16) * toDouble(inB, 16), 16))
+      }
+    }
+
+    launchCppTester((c: FixedMulT) => new FixedMulTTests(c))
+  }
+  
+  @Test def testFixedMulR() {
+    class FixedMulR extends Module {
+      val io = new Bundle {
+        val a = Fixed(INPUT, 32, 16)
+        val b = Fixed(INPUT, 32, 16)
+        val c = Fixed(OUTPUT, 32, 16)
+      }
+      io.c := io.a *& io.b
+    }
+
+    class FixedMulRTests(c : FixedMulR) extends Tester(c) {
+      val trials = 10
+      val r = scala.util.Random
+
+      for (i <- 0 until trials) {
+        val inA = BigInt(r.nextInt(1 << 15))
+        val inB = BigInt(r.nextInt(1 << 15))
+        poke(c.io.a, inA)
+        poke(c.io.b, inB)
+        expect(c.io.c, toFixed(toDouble(inA, 16) * toDouble(inB, 16), 16))
+      }
+    }
+
+    launchCppTester((c: FixedMulR) => new FixedMulRTests(c))
+  }
+
+  @Test def testFixedLine() {
+    class FixedLine extends Module {
+      val io = new Bundle {
+        val a = Fixed(INPUT, 32, 16)
+        val b = Fixed(INPUT, 32, 16)
+        val c = Fixed(OUTPUT, 32, 16)
+      }
+      val temp = io.a + io.b
+      val temp2 = temp - io.a
+      val temp3 = temp2 - io.b
+      io.c := temp3
+    }
+
+    class FixedLineTests(c : FixedLine) extends Tester(c) {
+      val trials = 10
+      val r = scala.util.Random
+
+      for (i <- 0 until trials) {
+        val inA = BigInt(r.nextInt(1 << 15))
+        val inB = BigInt(r.nextInt(1 << 15))
+        poke(c.io.a, inA)
+        poke(c.io.b, inB)
+        expect(c.io.c, toFixed(toDouble(inA, 16) + toDouble(inB, 16) - toDouble(inA, 16) - toDouble(inB, 16), 16))
+      }
+    }
+
+    launchCppTester((c: FixedLine) => new FixedLineTests(c))
+  }
+  
+  @Test def testFixedMux() {
+    class FixedMux extends Module {
+      val io = new Bundle {
+        val a = Fixed(INPUT, 32, 16)
+        val b = Fixed(INPUT, 32, 16)
+        val c = Fixed(INPUT, 32, 16)
+        val sel = Bool(INPUT)
+        val res = Fixed(OUTPUT, 32, 16)
+      }
+      val muxSel = Mux(io.sel, io.a + io.b, io.a + io.c)
+      io.res := muxSel
+    }
+
+    class FixedMuxTests(c : FixedMux) extends Tester(c) {
+      val trials = 10
+      val r = scala.util.Random
+
+      for (i <- 0 until trials) {
+        val inA = BigInt(r.nextInt(1 << 15))
+        val inB = BigInt(r.nextInt(1 << 15))
+        val inC = BigInt(r.nextInt(1 << 15))
+        val inSel = r.nextInt(2)
+        poke(c.io.a, inA)
+        poke(c.io.b, inB)
+        poke(c.io.c, inC)
+        poke(c.io.sel, inSel)
+        val res = if(inSel == 1) toDouble(inA, 16) + toDouble(inB, 16) else toDouble(inA, 16) + toDouble(inC, 16)
+        expect(c.io.res, toFixed(res, 16))
+      }
+    }
+
+    launchCppTester((c: FixedMux) => new FixedMuxTests(c))
+  }
+  
+  @Test def testFixedVec() {
+    class FixedVec extends Module {
+      val io = new Bundle {
+        val a = Vec.fill(8){Fixed(INPUT, 32, 16)}
+        val b = Vec.fill(8){Fixed(INPUT, 32, 16)}
+        val c = Fixed(OUTPUT, 32, 16)
+      }
+      io.c := (io.a, io.b).zipped.map(_+_).reduce(_+_)
+    }
+
+    class FixedVecTests(c : FixedVec) extends Tester(c) {
+      val trials = 10
+      val r = scala.util.Random
+
+      for (i <- 0 until trials) {
+        val inA = Array.fill(8){BigInt(r.nextInt(1 << 30))}
+        val inB = Array.fill(8){BigInt(r.nextInt(1 << 30))}
+        (c.io.a, inA).zipped.map((w, v) => poke(w, v))
+        (c.io.b, inB).zipped.map((w, v) => poke(w, v))
+        val res = (inA.map(v => toDouble(v, 16)), inB.map(v => toDouble(v, 16))).zipped.map(_+_).reduce(_+_)
+        expect(c.io.c, toFixed(res, 16))
+      }
+    }
+
+    launchCppTester((c: FixedVec) => new FixedVecTests(c))
+  }
+  
+  @Test def testFixedVec2() {
+    class FixedVec2 extends Module {
+      val io = new Bundle {
+        val a = Vec.fill(8){Fixed(INPUT, 32, 16)}
+        val b = Vec.fill(8){Fixed(INPUT, 32, 16)}
+        val c = Vec.fill(8){Fixed(OUTPUT, 32, 16)}
+      }
+      io.c := (io.a, io.b).zipped.map(_*&_)
+    }
+
+    class FixedVec2Tests(c : FixedVec2) extends Tester(c) {
+      val trials = 10
+      val r = scala.util.Random
+
+      for (i <- 0 until trials) {
+        val inA = Array.fill(8){BigInt(r.nextInt(1 << 15))}
+        val inB = Array.fill(8){BigInt(r.nextInt(1 << 15))}
+        (c.io.a, inA).zipped.map((w, v) => poke(w, v))
+        (c.io.b, inB).zipped.map((w, v) => poke(w, v))
+        val res = (inA.map(v => toDouble(v, 16)), inB.map(v => toDouble(v, 16))).zipped.map(_*_)
+        (c.io.c, res).zipped.map((w, v) => expect(w, toFixed(v, 16)))
+      }
+    }
+
+    launchCppTester((c: FixedVec2) => new FixedVec2Tests(c))
+  }
+}

--- a/src/test/scala/FixedTest.scala
+++ b/src/test/scala/FixedTest.scala
@@ -485,8 +485,16 @@ class FixedSuite extends TestSuite {
       val r = scala.util.Random
 
       for (i <- 0 until trials) {
-        var inA = BigInt(r.nextInt(1 << 22))
-        var inB = BigInt(r.nextInt(1 << 22))
+        var inA = BigInt(r.nextInt(1 << 22)) //BigInt(670823)
+        var inB = BigInt(r.nextInt(1 << 22)) //BigInt(2613)
+        var doubleA = toDouble(inA, 16)
+        var doubleB = toDouble(inB, 16)
+        while(doubleA/doubleB > scala.math.pow(2, 8)) {
+          inA = BigInt(r.nextInt(1 << 22))
+          inB = BigInt(r.nextInt(1 << 22))
+          doubleA = toDouble(inA, 16)
+          doubleB = toDouble(inB, 16)
+        }
         poke(c.io.a, inA)
         poke(c.io.b, inB)
         val div = toDouble(inA, 16) / toDouble(inB, 16)
@@ -518,6 +526,14 @@ class FixedSuite extends TestSuite {
       for (i <- 0 until trials) {
         var inA = BigInt(r.nextInt(1 << 22))
         var inB = BigInt(r.nextInt(1 << 22))
+        var doubleA = toDouble(inA, 16)
+        var doubleB = toDouble(inB, 16)
+        while(doubleA/doubleB > scala.math.pow(2, 8)) {
+          inA = BigInt(r.nextInt(1 << 22))
+          inB = BigInt(r.nextInt(1 << 22))
+          doubleA = toDouble(inA, 16)
+          doubleB = toDouble(inB, 16)
+        }
         poke(c.io.a, inA)
         poke(c.io.b, inB)
         step(5)

--- a/src/test/scala/FixedTest.scala
+++ b/src/test/scala/FixedTest.scala
@@ -465,9 +465,9 @@ class FixedSuite extends TestSuite {
   @Test def testFixedNDiv() {
     class FixedNDiv extends Module {
       val io = new Bundle {
-        val a = Fixed(INPUT, 32, 16)
-        val b = Fixed(INPUT, 32, 16)
-        val c = Fixed(OUTPUT, 32, 16)
+        val a = Fixed(INPUT, 16, 8)
+        val b = Fixed(INPUT, 16, 8)
+        val c = Fixed(OUTPUT, 16, 8)
       }
       io.c := io.a /& io.b
     }
@@ -479,20 +479,20 @@ class FixedSuite extends TestSuite {
       for (i <- 0 until trials) {
 
         // For the testing find two numbers that we also give a number that is representable in fixed point
-        var inA = BigInt(r.nextInt(1 << 30))
-        var inB = BigInt(r.nextInt(1 << 30))
-        var doubleA = toDouble(inA, 16)
-        var doubleB = toDouble(inB, 16)
-        while(  scala.math.abs(toDouble(toFixedT(doubleA / doubleB, 16), 16) - doubleA/doubleB) > scala.math.pow(2, -17)) {
-          inA = BigInt(r.nextInt(1 << 30))
-          inB = BigInt(r.nextInt(1 << 30))
-          doubleA = toDouble(inA, 16)
-          doubleB = toDouble(inB, 16)
+        var inA = BigInt(r.nextInt(1 << 14))
+        var inB = BigInt(r.nextInt(1 << 14))
+        var doubleA = toDouble(inA, 8)
+        var doubleB = toDouble(inB, 8)
+        while(  scala.math.abs(toDouble(toFixedT(doubleA / doubleB, 8), 8) - doubleA/doubleB) > scala.math.pow(2, -9)) {
+          inA = BigInt(r.nextInt(1 << 14))
+          inB = BigInt(r.nextInt(1 << 14))
+          doubleA = toDouble(inA, 8)
+          doubleB = toDouble(inB, 8)
         }
         poke(c.io.a, inA)
         poke(c.io.b, inB)
-        val div = toDouble(inA, 16) / toDouble(inB, 16)
-        expect(c.io.c, toFixedT(div, 16))
+        val div = toDouble(inA, 8) / toDouble(inB, 8)
+        expect(c.io.c, toFixedT(div, 8))
       }
     }
 

--- a/src/test/scala/FixedTest.scala
+++ b/src/test/scala/FixedTest.scala
@@ -46,7 +46,7 @@ class FixedSuite extends TestSuite {
   def toFixed(x : Double, fracWidth : Int) : BigInt = BigInt(scala.math.round(x*scala.math.pow(2, fracWidth)))
   def toDouble(x : BigInt, fracWidth : Int) : Double = x.toDouble/scala.math.pow(2, fracWidth)
 
-  // Newton-Rhapson to find 1/x - x_(t+1) = x_t(2 - a*x_t)
+  // Newton-Raphson to find 1/x - x_(t+1) = x_t(2 - a*x_t)
   def performNR(in : Double, xt : Double) : Double = xt*(2.0 - in*xt)
 
   def tailNR(in : Double, xt : Double, it : Int) : Double = {


### PR DESCRIPTION
Added Newton-Raphson Approximate Division to Fixed data type.
Includes: Optional Pipelining, Parameterised Lookup table precision and parameterised number of iterations

Updated test case with pipelined and non-pipelined NR Div.

(not sure why all of the accepted commits have been added to this pull request)