### PR TITLE
 Insert and Extract are not TypeOnly nodes.

### DIFF
--- a/src/main/scala/Extract.scala
+++ b/src/main/scala/Extract.scala
@@ -147,4 +147,7 @@ class Extract extends Node {
             " W0Wtransform", line)
     }
   }
+
+  // Chisel3 - this node contains data - used for verifying Wire() wrapping
+  override def isTypeOnly = false
 }

--- a/src/main/scala/Insert.scala
+++ b/src/main/scala/Insert.scala
@@ -43,4 +43,7 @@ class Insert(tgt: Bits, bit: UInt, length: Int) extends proc {
       tgt := UInt(tgt.next) & ~shiftedMask | fill
     }
   }
+
+  // Chisel3 - this node contains data - used for verifying Wire() wrapping
+  override def isTypeOnly = false
 }

--- a/src/test/scala/Chisel3Compatibility.scala
+++ b/src/test/scala/Chisel3Compatibility.scala
@@ -154,4 +154,31 @@ class Chisel3CompatibilitySuite extends TestSuite {
     }
     assertTrue(ChiselError.hasErrors)
   }
+
+  @Test def testSubwordNoWireWrap() {
+    println("\ntestSubwordNoWireWrap ...")
+
+    class SubwordNoWire() extends Module {
+    
+      val io = new Bundle {
+        val out = UInt(OUTPUT, 16)
+      }
+
+      // The following should pass without a Wire wrapper.
+      val foo = Reg(Bits(width = 16))
+      foo(0) := UInt(1)
+      io.out := foo
+    }
+
+    class WireTester(c: SubwordNoWire) extends Tester(c) {
+      expect(c.io.out, 1)
+    }
+
+    val testArgs = chiselEnvironmentArguments() ++ Array("--targetDir", dir.getPath.toString(),
+          "--minimumCompatibility", "3.0.0", "--wError", "--backend", "c", "--genHarness", "--compile", "--test")
+    
+    // This should pass (no Wire() wrapper)
+    chiselMainTest(testArgs, () => Module(new SubwordNoWire())){ c => new WireTester(c) }
+    assertFalse(ChiselError.hasErrors)
+  }
 }


### PR DESCRIPTION
The folowing should pass without a Wire wrapper.
      val foo = Reg(Bits(width = 16))
      foo(0) := UInt(1)