### PR TITLE
Generate gtkwave compatible --vcdMem signals.

### DIFF
--- a/src/main/scala/Vcd.scala
+++ b/src/main/scala/Vcd.scala
@@ -117,14 +117,14 @@ class VcdBackend(top: Module) extends Backend {
     for (mem <- sortedMems if c == mem.component && !mem.name.isEmpty) {
       for (offset <- 0 until mem.n) {
         write("  fputs(\"$var wire " + mem.needWidth() + " " + varName(baseIdx + offset) + " " +
-          top.stripComponent(emitRef(mem)) + "[%d] $end\\n\", f);\n".format(offset))
+          top.stripComponent(emitRef(mem)) + "(%d) $end\\n\", f);\n".format(offset))
       }
       baseIdx += mem.n
     }
     for (rom <- sortedROMs if c == rom.component && !rom.name.isEmpty) {
       for (offset <- 0 until rom.lits.size) {
         write("  fputs(\"$var wire " + rom.needWidth() + " " + varName(baseIdx + offset) + " " +
-          top.stripComponent(emitRef(rom)) + "[%d] $end\\n\", f);\n".format(offset))
+          top.stripComponent(emitRef(rom)) + "(%d) $end\\n\", f);\n".format(offset))
       }
       baseIdx += rom.lits.size
     }
@@ -141,14 +141,14 @@ class VcdBackend(top: Module) extends Backend {
     for (mem <- sortedMems if mem.name.isEmpty) {
       for (offset <- 0 until mem.n) {
         write("  fputs(\"$var wire " + mem.needWidth() + " " + varName(baseIdx + offset) + " " +
-          top.stripComponent(emitRef(mem)) + "[%d] $end\\n\", f);\n".format(offset))
+          top.stripComponent(emitRef(mem)) + "(%d) $end\\n\", f);\n".format(offset))
       }
       baseIdx += mem.n
     }
     for (rom <- sortedROMs if rom.name.isEmpty) {
       for (offset <- 0 until rom.lits.size) {
         write("  fputs(\"$var wire " + rom.needWidth() + " " + varName(baseIdx + offset) + " " +
-          top.stripComponent(emitRef(rom)) + "[%d] $end\\n\", f);\n".format(offset))
+          top.stripComponent(emitRef(rom)) + "(%d) $end\\n\", f);\n".format(offset))
       }
       baseIdx += rom.lits.size
     }


### PR DESCRIPTION
ROM and RAM contents are currently named like this in th VCD file:

reg[0]
reg[1]
etc.

Gtkwave is an open source and AFAIK popular waveform viewer, but it
has a bug where it isn't able parse signals with the '['
character. This commit changes the naming to be like:

reg(0)
reg(1)
etc.

which it is able to parse.

I have reported this on a GTKWave mailing list[0], but I fear it will take a while for this to be fixed.
It seemed easier to just work around this in Chisel.

[0] http://sourceforge.net/p/gtkwave/mailman/message/34339247/