### PR TITLE
The Mem class used to inherit setName which was useful for keeping

### DIFF
--- a/src/main/scala/Mem.scala
+++ b/src/main/scala/Mem.scala
@@ -279,4 +279,6 @@ class SeqMem[T <: Data](out: T, n: Int) {
 
   def write(addr: UInt, data: T): Unit = mem.write(addr, data)
   def write(addr: UInt, data: T, mask: UInt): Unit = mem.write(addr, data, mask)
+
+  def setName(name: String): Unit = mem.setName(name)
 }


### PR DESCRIPTION
macro names fixed for the VLSI flow.  This pull request adds setName
to the new Seq class.