### PR TITLE
Move emitRef from Verilog to backend

### DIFF
--- a/src/main/scala/Backend.scala
+++ b/src/main/scala/Backend.scala
@@ -192,6 +192,8 @@ abstract class Backend extends FileSystemUtilities{
       comp dfs { 
         case reg: Reg if reg.name == "" =>
           reg setName "R" + reg.component.nextIndex
+        case clk: Clock if clk.name == "" =>
+          clk setName "C" + clk.component.nextIndex
         case node: Node if !node.isTypeNode && node.name == "" && node.compOpt != None =>
           node.name = "T" + node.component.nextIndex
         case _ =>
@@ -207,6 +209,8 @@ abstract class Backend extends FileSystemUtilities{
       comp dfs { 
         case reg: Reg =>
           reg setName namespace.getUniqueName(reg.name)
+        case clk: Clock =>
+          clk setName namespace.getUniqueName(clk.name)
         case node: Node if !node.isTypeNode && !node.isLit && !node.isIo => {
           // the isLit check should not be necessary
           // the isIo check is also strange and happens because parents see child io in the DFS
@@ -250,6 +254,8 @@ abstract class Backend extends FileSystemUtilities{
         node.name
       case _: Reg =>
         if (node.named) node.name else "R" + node.emitIndex
+      case _: Clock =>
+        if (node.named) node.name else "C" + node.emitIndex
       case _ =>
         if (node.named) node.name else "T" + node.emitIndex
     }
@@ -814,8 +820,6 @@ abstract class Backend extends FileSystemUtilities{
 
     verifyComponents
 
-    ChiselError.info("giving names")
-    nameAll
     ChiselError.checkpoint()
 
     ChiselError.info("executing custom transforms")

--- a/src/main/scala/Verilog.scala
+++ b/src/main/scala/Verilog.scala
@@ -101,10 +101,8 @@ class VerilogBackend extends Backend {
   override def emitRef(node: Node): String = {
     node match {
       case x: Literal => emitLit(x.value, x.needWidth())
-      case _: Reg =>
-        if (node.name != "") node.name else "R" + node.emitIndex
       case _ =>
-        if (node.name != "") node.name else "T" + node.emitIndex
+          super.emitRef(node)
     }
   }
 


### PR DESCRIPTION
Currently not passing the tests as for some test cases are named twice and hence index does not start at 0.
Not sure where this is happening, but seems like it shouldn't be. Any suggestions on where to look?