### PR TITLE
Fixed Update

### DIFF
--- a/src/main/scala/Fixed.scala
+++ b/src/main/scala/Fixed.scala
@@ -108,30 +108,45 @@ class Fixed(var fractionalWidth : Int = 0) extends Bits with Num[Fixed] {
     /** Convert a Node to a Fixed data type with the same fractional width as this instantiation */
     override def fromNode(n : Node): this.type = {
         val res = Fixed(OUTPUT).asTypeFor(n).asInstanceOf[this.type]
-        res.fractionalWidth = this.fractionalWidth
+        res.fractionalWidth = this.getFractionalWidth()
         res
     }
 
     /** Create a Fixed representation from an Int */
-    override def fromInt(x : Int) : this.type = {
-        Fixed(x, this.getWidth(), this.fractionalWidth).asInstanceOf[this.type]
-    }
+    override def fromInt(x : Int) : this.type = Fixed(x, this.getWidth(), this.getFractionalWidth()).asInstanceOf[this.type]
 
     /** clone this Fixed instantiation */
-    override def cloneType: this.type = {
-        val res = Fixed(this.dir, this.getWidth(), this.fractionalWidth).asInstanceOf[this.type];
-        res
+    override def cloneType: this.type = Fixed(this.dir, this.getWidth(), this.getFractionalWidth()).asInstanceOf[this.type];
+
+    override protected def colonEquals(that : Bits): Unit = that match {
+      case f: Fixed => {
+        val res = if((f.getWidth() == this.getWidth()*2) && (f.getFractionalWidth() == this.getFractionalWidth()*2)) {
+          truncate(f, this.getFractionalWidth())
+        } else {
+          checkAligned(f)
+          f
+        }
+        super.colonEquals(res)
+      }
+      case _ => illegalAssignment(that)
     }
 
-    def getFractionalWidth : Int = this.fractionalWidth
+    def getFractionalWidth() : Int = this.fractionalWidth
+
+    private def truncate(f : Fixed, truncateAmount : Int) : Fixed = fromSInt(f.toSInt >> UInt(truncateAmount))
+    private def truncate(f : SInt, truncateAmount : Int) : SInt = f >> UInt(truncateAmount)
 
     /** Ensure two Fixed point data types have the same fractional width, Error if not */
-    def checkAligned(b : Fixed) = if(this.fractionalWidth != b.fractionalWidth) ChiselError.error(this.fractionalWidth + " Fractional Bits does not match " + b.fractionalWidth)
+    private def checkAligned(b : Fixed) {
+      if(this.getFractionalWidth() != b.getFractionalWidth()) ChiselError.error(this.getFractionalWidth() + " Fractional Bits does not match " + b.getFractionalWidth())
+      if(this.getWidth() != b.getWidth()) ChiselError.error(this.getWidth() + " Width does not match " + b.getWidth())
+    }
 
     /** Convert a SInt to a Fixed by reinterpreting the Bits */
-    def fromSInt(s : SInt) : Fixed = {
+    private def fromSInt(s : SInt, width : Int = this.getWidth(), fracWidth : Int = this.getFractionalWidth()) : Fixed = {
         val res = chiselCast(s){Fixed()}
-        res.fractionalWidth = fractionalWidth
+        res.fractionalWidth = fracWidth
+        res.width = width
         res
     }
 
@@ -155,7 +170,7 @@ class Fixed(var fractionalWidth : Int = 0) extends Bits with Num[Fixed] {
         checkAligned(b)
         this.toSInt <= b.toSInt
     }
-    
+
     def === (b : Fixed) : Bool = {
         checkAligned(b)
         this.toSInt === b.toSInt
@@ -166,7 +181,7 @@ class Fixed(var fractionalWidth : Int = 0) extends Bits with Num[Fixed] {
     }
 
     // Arithmetic Operators
-    def unary_-() : Fixed = Fixed(0, this.getWidth(), this.fractionalWidth) - this
+    def unary_-() : Fixed = Fixed(0, this.getWidth(), this.getFractionalWidth()) - this
 
     def + (b : Fixed) : Fixed = {
         checkAligned(b)
@@ -178,26 +193,36 @@ class Fixed(var fractionalWidth : Int = 0) extends Bits with Num[Fixed] {
         fromSInt(this.toSInt - b.toSInt)
     }
 
+    /** Multiply increasing the Bit Width */
+    def * (b : Fixed) : Fixed = {
+        checkAligned(b)
+        val temp = this.toSInt * b.toSInt
+        fromSInt(temp, temp.getWidth(), this.getFractionalWidth()*2)
+    }
+
     /** Multiply with one bit of rounding */
     def *& (b : Fixed) : Fixed = {
         checkAligned(b)
         val temp = this.toSInt * b.toSInt
-        val res = temp + ((temp & UInt(1)<<UInt(this.fractionalWidth-1))<<UInt(1))
-        fromSInt(res >> UInt(this.fractionalWidth))
+        val res = temp + ((temp & UInt(1)<<UInt(this.getFractionalWidth()-1))<<UInt(1))
+        fromSInt(truncate(res, this.getFractionalWidth()))
     }
 
     /** Multiply truncating the result to the same Fixed format */
-    def * (b : Fixed) : Fixed = {
+    def *% (b : Fixed) : Fixed = {
         checkAligned(b)
         val temp = this.toSInt * b.toSInt
-        fromSInt(temp >> UInt(this.fractionalWidth))
+        fromSInt(truncate(temp, this.getFractionalWidth()))
     }
 
     def / (b : Fixed) : Fixed = {
         checkAligned(b)
-        fromSInt((this.toSInt << UInt(this.fractionalWidth)) / b.toSInt)
+        fromSInt((this.toSInt << UInt(this.getFractionalWidth())) / b.toSInt)
     }
 
-    /** The remainder of the division this/b */
-    def % (b : Fixed) : Fixed = (this / b) & Fill(this.fractionalWidth, UInt(1))
+    /** This is just the modulo of the two fixed point bit representations changed into SInt and operated on */
+    def % (b : Fixed) : Fixed = {
+      checkAligned(b)
+      fromSInt(this.toSInt % b.toSInt)
+    }
 }

--- a/src/test/scala/FixedTest.scala
+++ b/src/test/scala/FixedTest.scala
@@ -135,8 +135,8 @@ class FixedSuite extends TestSuite {
       val r = scala.util.Random
 
       for (i <- 0 until trials) {
-        val inA = BigInt(r.nextInt(1 << 30))
-        val inB = BigInt(r.nextInt(1 << 30))
+        val inA = BigInt(r.nextInt(1 << 30)) * scala.math.pow(-1, r.nextInt(2)).toInt
+        val inB = BigInt(r.nextInt(1 << 30)) * scala.math.pow(-1, r.nextInt(2)).toInt
         poke(c.io.a, inA)
         poke(c.io.b, inB)
         expect(c.io.c, toFixed(toDouble(inA, 16) + toDouble(inB, 16), 16))
@@ -161,8 +161,8 @@ class FixedSuite extends TestSuite {
       val r = scala.util.Random
 
       for (i <- 0 until trials) {
-        val inA = BigInt(r.nextInt(1 << 30))
-        val inB = BigInt(r.nextInt(1 << 30))
+        val inA = BigInt(r.nextInt(1 << 30)) * scala.math.pow(-1, r.nextInt(2)).toInt
+        val inB = BigInt(r.nextInt(1 << 30)) * scala.math.pow(-1, r.nextInt(2)).toInt
         poke(c.io.a, inA)
         poke(c.io.b, inB)
         expect(c.io.c, toFixed(toDouble(inA, 16) - toDouble(inB, 16), 16))
@@ -186,7 +186,7 @@ class FixedSuite extends TestSuite {
       val r = scala.util.Random
 
       for (i <- 0 until trials) {
-        val inA = BigInt(r.nextInt(1 << 30))
+        val inA = BigInt(r.nextInt(1 << 30)) * scala.math.pow(-1, r.nextInt(2)).toInt
         poke(c.io.a, inA)
         step(1)
         expect(c.io.c, inA)
@@ -210,7 +210,7 @@ class FixedSuite extends TestSuite {
       val r = scala.util.Random
 
       for (i <- 0 until trials) {
-        val inA = BigInt(r.nextInt(1 << 30))
+        val inA = BigInt(r.nextInt(1 << 30)) * scala.math.pow(-1, r.nextInt(2)).toInt
         poke(c.io.a, inA)
         expect(c.io.c, -inA)
       }
@@ -240,8 +240,8 @@ class FixedSuite extends TestSuite {
       val r = scala.util.Random
 
       for (i <- 0 until trials) {
-        val inA = BigInt(r.nextInt(1 << 30))
-        val inB = BigInt(r.nextInt(1 << 30))
+        val inA = BigInt(r.nextInt(1 << 30)) * scala.math.pow(-1, r.nextInt(2)).toInt
+        val inB = BigInt(r.nextInt(1 << 30)) * scala.math.pow(-1, r.nextInt(2)).toInt
         poke(c.io.a, inA)
         poke(c.io.b, inB)
         expect(c.io.gt, Bool(inA > inB).litValue())
@@ -271,13 +271,13 @@ class FixedSuite extends TestSuite {
       for (i <- 0 until trials) {
 
         // For the testing find two numbers that we also give a number that is representable in fixed point
-        var inA = BigInt(r.nextInt(1 << 30))
-        var inB = BigInt(r.nextInt(1 << 30))
+        var inA = BigInt(r.nextInt(1 << 30)) * scala.math.pow(-1, r.nextInt(2)).toInt
+        var inB = BigInt(r.nextInt(1 << 30)) * scala.math.pow(-1, r.nextInt(2)).toInt
         var doubleA = toDouble(inA, 16)
         var doubleB = toDouble(inB, 16)
         while(  scala.math.abs(toDouble(toFixedT(doubleA / doubleB, 16), 16) - doubleA/doubleB) > scala.math.pow(2, -17)) {
-          inA = BigInt(r.nextInt(1 << 30))
-          inB = BigInt(r.nextInt(1 << 30))
+          inA = BigInt(r.nextInt(1 << 30)) * scala.math.pow(-1, r.nextInt(2)).toInt
+          inB = BigInt(r.nextInt(1 << 30)) * scala.math.pow(-1, r.nextInt(2)).toInt
           doubleA = toDouble(inA, 16)
           doubleB = toDouble(inB, 16)
         }
@@ -305,8 +305,8 @@ class FixedSuite extends TestSuite {
       val r = scala.util.Random
 
       for (i <- 0 until trials) {
-        val inA = BigInt(r.nextInt(1 << 15))
-        val inB = BigInt(r.nextInt(1 << 15))
+        val inA = BigInt(r.nextInt(1 << 15)) * scala.math.pow(-1, r.nextInt(2)).toInt
+        val inB = BigInt(r.nextInt(1 << 15)) * scala.math.pow(-1, r.nextInt(2)).toInt
         poke(c.io.a, inA)
         poke(c.io.b, inB)
         expect(c.io.c, toFixedT(toDouble(inA, 16) * toDouble(inB, 16), 32))
@@ -331,11 +331,16 @@ class FixedSuite extends TestSuite {
       val r = scala.util.Random
 
       for (i <- 0 until trials) {
-        val inA = BigInt(r.nextInt(1 << 15))
-        val inB = BigInt(r.nextInt(1 << 15))
+        val inA = BigInt(r.nextInt(1 << 15)) * scala.math.pow(-1, r.nextInt(2)).toInt
+        val inB = BigInt(r.nextInt(1 << 15)) * scala.math.pow(-1, r.nextInt(2)).toInt
         poke(c.io.a, inA)
         poke(c.io.b, inB)
-        expect(c.io.c, toFixedT(toDouble(inA, 16) * toDouble(inB, 16), 16))
+        val expected = toFixedT(toDouble(inA, 16) * toDouble(inB, 16), 16)
+        val res = peek(c.io.c)
+        val errorVal = scala.math.abs(scala.math.abs(expected.toInt) - scala.math.abs(res.toInt))
+        val error = errorVal > 1
+        val errorMessage = if(error) "Error outside acceptiable Range: " + errorVal.toString else "Error within acceptiable range: " + errorVal.toString
+        expect(!error, errorMessage)
       }
     }
 
@@ -357,8 +362,8 @@ class FixedSuite extends TestSuite {
       val r = scala.util.Random
 
       for (i <- 0 until trials) {
-        val inA = BigInt(r.nextInt(1 << 15))
-        val inB = BigInt(r.nextInt(1 << 15))
+        val inA = BigInt(r.nextInt(1 << 15)) * scala.math.pow(-1, r.nextInt(2)).toInt
+        val inB = BigInt(r.nextInt(1 << 15)) * scala.math.pow(-1, r.nextInt(2)).toInt
         poke(c.io.a, inA)
         poke(c.io.b, inB)
         expect(c.io.c, toFixed(toDouble(inA, 16) * toDouble(inB, 16), 16))
@@ -386,8 +391,8 @@ class FixedSuite extends TestSuite {
       val r = scala.util.Random
 
       for (i <- 0 until trials) {
-        val inA = BigInt(r.nextInt(1 << 15))
-        val inB = BigInt(r.nextInt(1 << 15))
+        val inA = BigInt(r.nextInt(1 << 15)) * scala.math.pow(-1, r.nextInt(2)).toInt
+        val inB = BigInt(r.nextInt(1 << 15)) * scala.math.pow(-1, r.nextInt(2)).toInt
         poke(c.io.a, inA)
         poke(c.io.b, inB)
         expect(c.io.c, toFixed((toDouble(inA, 16) + toDouble(inB, 16)) * toDouble(inA, 16) - toDouble(inB, 16), 16))
@@ -415,9 +420,9 @@ class FixedSuite extends TestSuite {
       val r = scala.util.Random
 
       for (i <- 0 until trials) {
-        val inA = BigInt(r.nextInt(1 << 15))
-        val inB = BigInt(r.nextInt(1 << 15))
-        val inC = BigInt(r.nextInt(1 << 15))
+        val inA = BigInt(r.nextInt(1 << 15)) * scala.math.pow(-1, r.nextInt(2)).toInt
+        val inB = BigInt(r.nextInt(1 << 15)) * scala.math.pow(-1, r.nextInt(2)).toInt
+        val inC = BigInt(r.nextInt(1 << 15)) * scala.math.pow(-1, r.nextInt(2)).toInt
         val inSel = r.nextInt(2)
         poke(c.io.a, inA)
         poke(c.io.b, inB)
@@ -446,8 +451,8 @@ class FixedSuite extends TestSuite {
       val r = scala.util.Random
 
       for (i <- 0 until trials) {
-        val inA = Array.fill(8){BigInt(r.nextInt(1 << 30))}
-        val inB = Array.fill(8){BigInt(r.nextInt(1 << 30))}
+        val inA = Array.fill(8){BigInt(r.nextInt(1 << 30)) * scala.math.pow(-1, r.nextInt(2)).toInt}
+        val inB = Array.fill(8){BigInt(r.nextInt(1 << 30)) * scala.math.pow(-1, r.nextInt(2)).toInt}
         (c.io.a, inA).zipped.map((w, v) => poke(w, v))
         (c.io.b, inB).zipped.map((w, v) => poke(w, v))
         val res = (inA.map(v => toDouble(v, 16)), inB.map(v => toDouble(v, 16))).zipped.map(_+_).reduce(_+_)
@@ -473,8 +478,8 @@ class FixedSuite extends TestSuite {
       val r = scala.util.Random
 
       for (i <- 0 until trials) {
-        val inA = Array.fill(8){BigInt(r.nextInt(1 << 15))}
-        val inB = Array.fill(8){BigInt(r.nextInt(1 << 15))}
+        val inA = Array.fill(8){BigInt(r.nextInt(1 << 15)) * scala.math.pow(-1, r.nextInt(2)).toInt}
+        val inB = Array.fill(8){BigInt(r.nextInt(1 << 15)) * scala.math.pow(-1, r.nextInt(2)).toInt}
         (c.io.a, inA).zipped.map((w, v) => poke(w, v))
         (c.io.b, inB).zipped.map((w, v) => poke(w, v))
         val res = (inA.map(v => toDouble(v, 16)), inB.map(v => toDouble(v, 16))).zipped.map(_*_)


### PR DESCRIPTION
Updated this.fractionWidth to use the getter (this.getFractionalWidth())
Changed the default multiplication to keep of the multiplication bits
Moved multiplication by truncation to *%
Updated fromSInt to ensure that the resulting width is consist for operation
Updated *% and *& to ensure that the resulting width and fractional width are the same as the multiplier inputs
Updated % to just do the normal integer modulo by transforming the inputs into integers
Made a small change the colonEqual to handle the case where you assign a Fixed number to another which is half of the width and fractional length.
Added two truncate helper functions
Updated check aligned to ensure that both the widths and fractional widths are the same
Added test cases for the changes above