### PR TITLE
Update Enum Doc for Scala's limit on Tuple size

### DIFF
--- a/src/main/scala/Enum.scala
+++ b/src/main/scala/Enum.scala
@@ -33,11 +33,12 @@ package Chisel
 /** An object for creating C style Enums */
 object Enum {
   import Literal.sizeof
-  /** create n enum values of given type
+  /** create n enum values of given type for n <= 22
     * @param nodeType the type of node to create
     * @param n the number of nodes to create
     * @example {{{ val s1 :: s2 :: s3 :: Nil = Enum(UInt(), 3) }}}
-    * @note When declaring vals the first character must be lower case, ie S1 is illegal */
+    * @note When declaring vals the first character must be lower case, ie S1 is illegal
+    * @note The 22 state size limitation is due to the maximum Scala tuple size of 22 (other methods avoid this limitation)*/
   def apply[T <: UInt](nodeType: T, n: Int): List[T] = (Range(0, n, 1).map(x => (Lit(x, sizeof(n-1))(nodeType)))).toList;
 
   /** create enum values of given type and names
@@ -49,7 +50,11 @@ object Enum {
   /** create enum values of given type and names
     * @param nodeType the type of node to create
     * @param l a list of symbols
-    * @return a map of symbols to a node created */
+    * @return a map of symbols to a node created
+    * @example {{{
+    * val states = Enum(UInt(), List('s1, 's2, 's3))
+    * val state = Reg(UInt(), init = states('s1))
+    * }}}*/
   def apply[T <: UInt](nodeType: T, l: List[Symbol]): Map[Symbol, T] = (l zip (Range(0, l.length, 1).map(x => Lit(x, sizeof(l.length-1))(nodeType)))).toMap;
 
 }


### PR DESCRIPTION
Scala has a built in size limitation on the size of a Tuple of 22 (https://groups.google.com/forum/#!topic/scala-language/wE1eLIOBBR4). This becomes a problem if you try to define an Enum in the "standard" way as outlined in the documentation. 

This updates the documentation to make this issue known and provides a new example for how to use one of the alternative methods which does not have this size 22 limitation.