### PR TITLE
Revert BuildInfo code due to problems when included as a submodule.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -72,10 +72,4 @@ lazy val chiselBuildSettings = Seq (
  )
 
 lazy val chisel = (project in file(".")).
-  enablePlugins(BuildInfoPlugin).
-  settings(chiselBuildSettings: _*).
-  settings(
-    buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
-    // We should really be using name.vale, but currently, the package is "Chisel" (uppercase first letter)
-    buildInfoPackage := /* name.value */ "Chisel"
-  )
+  settings(chiselBuildSettings: _*)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,5 +7,3 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.7.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
-
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.5.0")

--- a/src/main/scala/Driver.scala
+++ b/src/main/scala/Driver.scala
@@ -32,7 +32,6 @@ package Chisel
 
 import collection.mutable.{ArrayBuffer, HashSet, HashMap, LinkedHashMap, Stack, Queue => ScalaQueue}
 import sys.process.stringSeqToProcess
-import BuildInfo._
 
 object Driver extends FileSystemUtilities{
   def apply[T <: Module](args: Array[String], gen: () => T, wrapped:Boolean): T = {
@@ -408,7 +407,6 @@ object Driver extends FileSystemUtilities{
         }
         case "--minimumCompatibility" => minimumCompatibility = Version(args(i + 1)); i += 1
         case "--wError" => wError = true
-        case "--version" => println(version)
         case any => ChiselError.warning("'" + arg + "' is an unknown argument.")
       }
       i += 1
@@ -492,7 +490,6 @@ object Driver extends FileSystemUtilities{
   var chiselConfigMode: Option[String] = None
   var chiselConfigDump: Boolean = false
   var startTime = 0L
-  val version = BuildInfo.version
   /* For tester */
   val signalMap = LinkedHashMap[Node, Int]()
   var nodeId = 0


### PR DESCRIPTION
We encounter

     error: not found: value sbtbuildinfo
      enablePlugins(sbtbuildinfo.BuildInfoPlugin).

when this plugin is enabled in a submodule (project) and the root project uses project/build.scala