### PR TITLE
Replace overridden setName in seqMem with a working setMemName method

### DIFF
--- a/src/main/scala/Mem.scala
+++ b/src/main/scala/Mem.scala
@@ -289,5 +289,5 @@ class SeqMem[T <: Data](out: T, val n: Int) extends Delay with VecLike[T] {
   def write(addr: UInt, data: T): Unit = mem.write(addr, data)
   def write(addr: UInt, data: T, mask: UInt): Unit = mem.write(addr, data, mask)
 
-  override def setName(name: String): Unit = mem.setName(name)
+  def setMemName(name: String): Unit = mem.setName(name)
 }


### PR DESCRIPTION
The addition of setName does not actually allow naming of memories in a
consistent way. This patch adds a setMemName method that accomplishes
what was originally intended for the overridden setName.