### PR TITLE
Swap the type and num_elements arguments for Vecs and Mems

### DIFF
--- a/src/main/scala/Vec.scala
+++ b/src/main/scala/Vec.scala
@@ -47,9 +47,15 @@ object VecMux {
 }
 
 object Vec {
-
-  def apply[T <: Data](gen: T, n: Int): Vec[T] = 
+ 
+  def apply[T <: Data](n: Int, gen: T): Vec[T] = 
     /* new */ Vec((0 until n).map(i => gen.cloneType))
+ 
+  def apply[T <: Data](gen: T, n: Int): Vec[T] = {
+    if (Driver.minimumCompatibility > "2")
+      ChiselError.warning("Vec(gen:T, n:Int) is deprecated. Please use Vec(n:Int, gen:T) instead.")
+    apply(n, gen)
+  }
 
   /** Returns a new *Vec* from a sequence of *Data* nodes.
     */


### PR DESCRIPTION
This pull request deprecates Vec(t, n) and SeqMem(t, n) and instead provides the new forms Vec(n, t) and SeqMem(n, t).

- The change to Vec() is to make the newer, upcoming Chisel3 form more readable.
- The change to SeqMem() is to make Mem()s and Vec()s more consistent. 

This PR (currently) leaves Mem() untouched. It does not appear possible to provide a similar deprecated path to swapping the Mem(out, n) arguments, as Scala will not allow the mixing of method-overloading and parameter input default values.