### PR TITLE
Swapped arguments (out,n) in Vec and Mem.

### DIFF
--- a/src/main/scala/ChiselUtil.scala
+++ b/src/main/scala/ChiselUtil.scala
@@ -434,7 +434,7 @@ class Queue[T <: Data](gen: T, val entries: Int, pipe: Boolean = false, flow: Bo
 {
   val io = new QueueIO(gen, entries)
 
-  val ram = Mem(gen, entries)
+  val ram = Mem(entries, gen)
   val enq_ptr = Counter(entries)
   val deq_ptr = Counter(entries)
   val maybe_full = Reg(init=Bool(false))
@@ -544,7 +544,7 @@ class AsyncFifo[T<:Data](gen: T, entries: Int, enq_clk: Clock, deq_clk: Clock) e
   io.enq.ready := not_full
   io.deq.valid := not_empty
 
-  val mem = Mem(gen, 1 << asize, clock=enq_clk)
+  val mem = Mem(1 << asize, gen, clock=enq_clk)
   when (io.enq.valid && io.enq.ready) {
     mem(wptr_bin(asize-1,0)) := io.enq.bits
   }

--- a/src/main/scala/FameBackend.scala
+++ b/src/main/scala/FameBackend.scala
@@ -101,7 +101,7 @@ class FameQueueTrackerIO() extends Bundle{
 
 class FameQueueTracker(num_tgt_entries: Int, num_tgt_cycles: Int) extends Module{
   val io = new FameQueueTrackerIO()
-  val aregs = Reg { Vec(UInt(0, width = log2Up(num_tgt_entries)), num_tgt_cycles) }
+  val aregs = Reg { Vec(num_tgt_cycles, UInt(0, width = log2Up(num_tgt_entries))) }
   val tail_pointer = Reg(init = UInt(1, width = log2Up(num_tgt_cycles)))
 
   val next_tail_pointer = Wire(UInt())

--- a/src/main/scala/Mem.scala
+++ b/src/main/scala/Mem.scala
@@ -36,7 +36,7 @@ import scala.collection.mutable.{ArrayBuffer, HashMap}
   a LFSR, which returns "1" on its first invocation).
   */
 object Mem {
-  private def construct[T <: Data](n: Int, t: T, seqRead: Boolean,
+  private def construct[T <: Data](n: Int, t: => T, seqRead: Boolean,
                        orderedWrites: Boolean,
                        clock: Clock): Mem[T] = {
     val gen = t.cloneType
@@ -46,15 +46,15 @@ object Mem {
     res
   }
 
-  def apply[T <: Data](n: Int, t: T): Mem[T] = {
+  def apply[T <: Data](n: Int, t: => T): Mem[T] = {
     construct(n, t, false, false, null)
   }
 
-  def apply[T <: Data](n: Int, t: T, clock: Clock): Mem[T] = {
+  def apply[T <: Data](n: Int, t: => T, clock: Clock): Mem[T] = {
     construct(n, t, false, false, clock)
   }
 
-  def apply[T <: Data](out: T, n: Int, seqRead: Boolean = false,
+  def apply[T <: Data](out: => T, n: Int, seqRead: Boolean = false,
                        orderedWrites: Boolean = false,
                        clock: Clock = null): Mem[T] = {
     if (Driver.minimumCompatibility > "2") {
@@ -278,15 +278,14 @@ class MemWrite(mem: Mem[_ <: Data], condi: Bool, addri: Node, datai: Node, maski
 
 // Chisel3
 object SeqMem {
-  def apply[T <: Data](n: Int, out: T): SeqMem[T] = {
+  def apply[T <: Data](n: Int, out: => T): SeqMem[T] = {
     val gen = out.cloneType
     Reg.validateGen(gen)
     new SeqMem(n, gen)
   }
 
-  def apply[T <: Data](out: T, n: Int): SeqMem[T] = {
-    if (Driver.minimumCompatibility > "2")
-      ChiselError.warning("SeqMem(out:T, n:Int) is deprecated. Please use SeqMem(n:Int, out:T) instead.")
+  @deprecated("SeqMem(out: => T, n:Int) is deprecated. Please use SeqMem(n:Int, out: => T) instead.", "2.29")
+  def apply[T <: Data](out: => T, n: Int): SeqMem[T] = {
     apply(n, out)
   }
 }

--- a/src/main/scala/Vec.scala
+++ b/src/main/scala/Vec.scala
@@ -47,12 +47,8 @@ object VecMux {
 }
 
 object Vec {
-  def apply[T <: Data](n: Int, t: T): Vec[T] =
-    apply((0 until n).map(i => t.cloneType))
-
-  def apply[T <: Data](gen: T, n: Int): Vec[T] = {
-    if (Driver.minimumCompatibility > "2")
-      ChiselError.warning("Vec(gen:T, n:Int) is deprecated. Please use Vec(n:Int, t:T) instead.")
+  @deprecated("Vec(gen: => T, n:Int) is deprecated. Please use Vec(n:Int, gen: => T) instead.", "2.29")
+  def apply[T <: Data](gen: => T, n: Int): Vec[T] = {
     apply(n, gen)
   }
 

--- a/src/main/scala/Vec.scala
+++ b/src/main/scala/Vec.scala
@@ -47,9 +47,14 @@ object VecMux {
 }
 
 object Vec {
+  def apply[T <: Data](n: Int, t: T): Vec[T] =
+    apply((0 until n).map(i => t.cloneType))
 
-  def apply[T <: Data](gen: T, n: Int): Vec[T] = 
-    /* new */ Vec((0 until n).map(i => gen.cloneType))
+  def apply[T <: Data](gen: T, n: Int): Vec[T] = {
+    if (Driver.minimumCompatibility > "2")
+      ChiselError.warning("Vec(gen:T, n:Int) is deprecated. Please use Vec(n:Int, t:T) instead.")
+    apply(n, gen)
+  }
 
   /** Returns a new *Vec* from a sequence of *Data* nodes.
     */

--- a/src/test/scala/BundleWire.scala
+++ b/src/test/scala/BundleWire.scala
@@ -23,9 +23,9 @@ class BundleWireSuite extends TestSuite {
     class BundleWire extends Module {
       val io = new Bundle {
         val in   = (new Coord).asInput
-        val outs = Vec((new Coord).asOutput, 4)
+        val outs = Vec(4, (new Coord).asOutput)
       }
-      val coords = Wire(Vec(new Coord, 4))
+      val coords = Wire(Vec(4, new Coord))
       for (i <- 0 until 4) {
         coords(i)  := io.in
         io.outs(i) := coords(i)

--- a/src/test/scala/DelayTest.scala
+++ b/src/test/scala/DelayTest.scala
@@ -108,7 +108,7 @@ class DelaySuite extends TestSuite {
         val addr = UInt(INPUT, width=32)
         val out = UInt(OUTPUT)
       }
-      val mem= Mem(UInt(width=32), 8)
+      val mem= Mem(8, UInt(width=32))
       io.out := mem(io.addr)
     }
     chiselMain(Array[String]("--v", "--inlineMem",
@@ -125,7 +125,7 @@ class DelaySuite extends TestSuite {
         val addr = UInt(INPUT, width=32)
         val out = UInt(OUTPUT)
       }
-      val mem = Mem(UInt(width=32), 8)
+      val mem = Mem(8, UInt(width=32))
       mem(io.addr) := mem(io.addr) + UInt(1)
       io.out := mem(io.addr)
     }
@@ -144,7 +144,7 @@ class DelaySuite extends TestSuite {
         val addr = UInt(INPUT, width=32)
         val out = UInt(OUTPUT)
       }
-      val mem= Mem(UInt(width=32), 8)
+      val mem= Mem(8, UInt(width=32))
       when( io.enable ) {
         mem(io.addr) := mem(io.addr) + UInt(1)
       }
@@ -167,7 +167,7 @@ class DelaySuite extends TestSuite {
         val addr = UInt(INPUT, width=32)
         val out = UInt(OUTPUT)
       }
-      val mem= Mem(UInt(width=32), 8)
+      val mem= Mem(8, UInt(width=32))
       when( io.enable ) {
         mem.write(io.addr, mem(io.addr), UInt(0xff00))
       }

--- a/src/test/scala/Risc.scala
+++ b/src/test/scala/Risc.scala
@@ -48,8 +48,8 @@ class RiscSuite extends TestSuite {
         val valid  = Bool(OUTPUT)
         val out    = Bits(OUTPUT, 32)
       }
-      val file = Mem(Bits(width = 32), 256)
-      val code = Mem(Bits(width = 32), 256)
+      val file = Mem(256, Bits(width = 32))
+      val code = Mem(256, Bits(width = 32))
       val pc   = Reg(init=UInt(0, 8))
       
       val add_op :: imm_op :: Nil = Enum(Bits(width = 8), 2)

--- a/src/test/scala/SeqMemSuite.scala
+++ b/src/test/scala/SeqMemSuite.scala
@@ -45,7 +45,7 @@ class SeqMemSuite extends TestSuite {
         val value   = UInt(INPUT, 32)
         val out    = UInt(OUTPUT, 32)
       }
-      val mem = SeqMem(UInt(width = 32), size)
+      val mem = SeqMem(size, UInt(width = 32))
       when(io.wEnable) {
         mem.write(io.addr, io.value)
       }

--- a/src/test/scala/VecApp.scala
+++ b/src/test/scala/VecApp.scala
@@ -4,8 +4,7 @@ import Chisel._
 class VecApp(n: Int, W: Int) extends Module {
   val io = new Bundle {
     val a = UInt(INPUT, n)
-    val i = Vec(Bits(INPUT, W), n)
-    // val o = Vec(n,  Bits(OUTPUT, W) )
+    val i = Vec(n, Bits(INPUT, W))
     val d = Bits(OUTPUT, W)
   }
   // for (j <- 0 until n)


### PR DESCRIPTION
(Deprecated Vec(out,n),Mem(out,n) and added Vec(n,t),Mem(n,t)).

   - This change, in preparation for Chisel3, makes Vec declarations
     more readable by putting the number of elements first.
   - It also makes Mem() consistent with the new Vec() syntax.
   - It changes ChiselUtil to use the new Mem().