### PR TITLE
Re-introduce MuxCase / PriorityMuxi'ing of bundles

### DIFF
--- a/src/main/scala/ChiselUtil.scala
+++ b/src/main/scala/ChiselUtil.scala
@@ -597,15 +597,15 @@ object Pipe
   */
 object PriorityMux
 {
-  def apply[T <: Bits](in: Iterable[(Bool, T)]): T = {
+  def apply[T <: Data](in: Iterable[(Bool, T)]): T = {
     if (in.size == 1) {
       in.head._2
     } else {
       Mux(in.head._1, in.head._2, apply(in.tail))
     }
   }
-  def apply[T <: Bits](sel: Iterable[Bool], in: Iterable[T]): T = apply(sel zip in)
-  def apply[T <: Bits](sel: Bits, in: Iterable[T]): T = apply((0 until in.size).map(sel(_)), in)
+  def apply[T <: Data](sel: Iterable[Bool], in: Iterable[T]): T = apply(sel zip in)
+  def apply[T <: Data](sel: Bits, in: Iterable[T]): T = apply((0 until in.size).map(sel(_)), in)
 }
 
 /** Returns a bit vector in which only the least-significant 1 bit in

--- a/src/main/scala/Mux.scala
+++ b/src/main/scala/Mux.scala
@@ -51,7 +51,7 @@ object MuxCase {
   /** @param default the default value if none are enabled
     * @param mapping a set of data values with associated enables
     * @return the first value in mapping that is enabled */
-  def apply[T <: Bits] (default: T, mapping: Seq[(Bool, T)]): T = {
+  def apply[T <: Data] (default: T, mapping: Seq[(Bool, T)]): T = {
     var res = default;
     for ((t, v) <- mapping.reverse){
       res = Mux(t, v, res);


### PR DESCRIPTION
This reverts some of the changes made in a4f5946c80e9e3533322477eccc7396db0c9d1a3. See commit message in https://github.com/ucb-bar/chisel/commit/31245360305f8ec1aa6b85cbfb7e0c5b5dceb614 for more details.

The type change should also allow Vec's to be used with these stdlib functions, but I have not tested this.