### PR TITLE
Fix printf output collection to pass FlushPrintfOutput test.

### DIFF
--- a/src/test/scala/FlushPrintfOutput.scala
+++ b/src/test/scala/FlushPrintfOutput.scala
@@ -58,7 +58,7 @@ class FlushPrintfOutput extends TestSuite {
         for (i <- 0 until 4) {
           step(1)
           // Fetch the output printed on stdout by the test.
-          val printfOutput = testOutputString
+          val printfOutput = accumulatedTestOutput.last
           val expectedString = m.counterString.format(i)
           assertTrue("incorrect output - %s".format(printfOutput), eliminateWhiteSpace(printfOutput) == eliminateWhiteSpace(expectedString))
         }


### PR DESCRIPTION
Rename testOutputString to accumulatedTestOutput and provide a mechanism to fetch the last output line.
Convert _logs to ArrayBuffer (from Queue) and use a last-printed index to track what's been printed so far.
This allows is to keep a single copy of all the printf output, accessible on an individual line basis (if so-desired).