### PR TITLE
Ensure testKeywordsNull() has an application to execute.

### DIFF
--- a/src/test/scala/NameTest.scala
+++ b/src/test/scala/NameTest.scala
@@ -597,6 +597,9 @@ class NameSuite extends TestSuite {
 
   @Test def testKeywordsNull() {
     println("testKeywordsNull:")
+    // Make sure we actually have a test to execute (the order of test runs is not defined,
+    //  so testKeywordsCpp or testKeywordsVerilog may not have run yet.
+    chiselMain(Array[String]("--backend", "c", "--genHarness", "--compile", "--targetDir", dir.getPath.toString()), () => Module(new KeywordsModule()))
     launchTester("null", (c: KeywordsModule) => new KeywordsModuleNullTests(c),
       Some((args: Array[String]) => args ++ Array("--testCommand", dir.getPath.toString() + "/NameSuite_KeywordsModule", "-q")))
   }


### PR DESCRIPTION
Since the order of test runs is indeterminate, we can't assume testKeywordsCpp() or testKeywordsVerilog() have run before testKeywordsNull(). The latter needs to prepare its test environment independently of other tests.