### PR TITLE
Implement rsha_n correctly

### DIFF
--- a/src/main/resources/emulator.h
+++ b/src/main/resources/emulator.h
@@ -203,7 +203,7 @@ static void rsha_n (val_t d[], const val_t s0[], const unsigned int amount, cons
   int n_shift_words    = amount / val_n_bits();
   unsigned int n_rev_shift_bits = val_n_bits() - n_shift_bits;
   int is_zero_carry    = n_shift_bits == 0;
-  int msb              = s0[nw-1] >> (w - nw*val_n_bits() - 1);
+  int msb              = s0[nw-1] >> (w - (nw-1)*val_n_bits() - 1);
   val_t carry = 0;
 
   n_shift_words = (n_shift_words < 0)  ? 0  : n_shift_words;
@@ -230,7 +230,7 @@ static void rsha_n (val_t d[], const val_t s0[], const unsigned int amount, cons
       d[i] = val_all_ones();
     } else {
       d[i] = d[i] | (val_all_ones() << (boundary - idx));
-      d[nw-1] = d[nw-1] & (val_all_ones() >> ((nw-1)*val_n_bits() - w));
+      d[nw-1] = d[nw-1] & (val_all_ones() >> (w - (nw-1)*val_n_bits()));
       return;
     }
   }

--- a/src/test/scala/LargeNumber.scala
+++ b/src/test/scala/LargeNumber.scala
@@ -222,6 +222,37 @@ class LargeNumberSuite extends TestSuite {
     launchCppTester((c: Rsh) => new RshTests(c))
   }
 
+  // regression test for github #576
+  @Test def testRshA576() {
+    class RightShift extends Module {
+      val W = 64
+
+      val io = new Bundle {
+        val a = SInt(INPUT, W)
+        val b = UInt(INPUT, log2Up(W))
+        val signed = Bool(INPUT)
+        val out = SInt(OUTPUT, W)
+      }
+
+      val toshift = Cat(io.a(W - 1) & io.signed, io.a).toSInt
+      io.out := toshift >> io.b
+    }
+
+    class RightShiftTester(c: RightShift) extends Tester(c) {
+      val test = BigInt("-8000000000000000", 16)
+
+      poke(c.io.a, test)
+      poke(c.io.signed, 1)
+
+      for (i <- 0 until 8) {
+        poke(c.io.b, i)
+        step(1)
+        expect(c.io.out, test >> i)
+      }
+    }
+    launchCppTester((c:RightShift) => new RightShiftTester(c))
+  }
+
   @Test def testRshExt() {
     class Rsh extends Module {
       val io = new Bundle {


### PR DESCRIPTION
I'm actually not sure this is correct, but the other version is
obviously wrong: it regularly shifts by an extremely large value (as the
result of unsigned underflow).  This actually manifests in rocket-chip,
Howie found and isolated a test case.

I found this using "-fsanitize=undefined" (kind of by accident, since as
far as I can tell this was just wrong), which seems like something that
should be run on emulator.h.  It's unfortunately a dynamic analysis, but
we should probably run it on rocket-chip.