### PR TITLE
Avoid Tester hang on bogus peek()/poke() - #581.

### DIFF
--- a/src/main/resources/sim_api.h
+++ b/src/main/resources/sim_api.h
@@ -139,7 +139,7 @@ private:
     if (!obj) {
       std::cerr << "Cannot find the object of id = " << id << std::endl;
       finish();
-      exit(0);
+      exit(2);		// Not a normal exit.
     }
     while(!recv_value(obj, force));
   }
@@ -151,7 +151,7 @@ private:
     if (!obj) {
       std::cerr << "Cannot find the object of id = " << id << std::endl;
       finish();
-      exit(0);
+      exit(2);		// Not a normal exit.
     }
     while(!send_value(obj));
   }
@@ -165,9 +165,8 @@ private:
     } else {
       int id = search(path);
       if (id < 0) {
+    	// Issue warning message but don't exit here.
         std::cerr << "Cannot find the object, " << path << std::endl;
-        finish();
-        exit(0);
       }
       while(!send_resp(id));
     }
@@ -180,7 +179,7 @@ private:
     if (!obj) {
       std::cerr << "Cannot find the object of id = " << id << std::endl;
       finish();
-      exit(0);
+      exit(2);		// Not a normal exit.
     }
     size_t chunk = get_chunk(obj);
     while(!send_resp(chunk));
@@ -290,7 +289,7 @@ protected:
     if (!file) {
       std::cerr << "Cannot open " << filename << std::endl;
       finish();
-      exit(0);
+      exit(2);		// Not a normal exit.
     } 
     std::string line;
     size_t id = 0;

--- a/src/main/scala/Tester.scala
+++ b/src/main/scala/Tester.scala
@@ -195,9 +195,14 @@ class Tester[+T <: Module](c: T, isTrace: Boolean = true) extends FileSystemUtil
   }
   /** Peek at the value of a node based on the path
     */
-  def peekPath(path: String) = {
+  def peekPath(path: String): BigInt = {
     val id = _signalMap getOrElseUpdate (path, getId(path))
-    peek(id, _chunks getOrElseUpdate (path, getChunk(id)))
+    if (id == -1) {
+      println("Can't find id for '%s'".format(path))
+      id
+    } else {
+      peek(id, _chunks getOrElseUpdate (path, getChunk(id)))
+    }
   }
   /** Peek at the value of a node
     * @param node Node to peek at
@@ -252,7 +257,11 @@ class Tester[+T <: Module](c: T, isTrace: Boolean = true) extends FileSystemUtil
     */
   def pokePath(path: String, v: BigInt, force: Boolean = false) {
     val id = _signalMap getOrElseUpdate (path, getId(path)) 
-    poke(id, _chunks getOrElseUpdate (path, getChunk(id)), v, force)
+    if (id == -1) {
+      println("Can't find id for '%s'".format(path))
+    } else {
+      poke(id, _chunks getOrElseUpdate (path, getChunk(id)), v, force)
+    }
   }
   /** set the value of a node
     * @param node The node to set


### PR DESCRIPTION
Return -1 on getid() failure (instead of abrupt exit).
If we are going to exit prematurely, don't do a normal exit.