### PR TITLE
Added an equal bits method

### DIFF
--- a/src/main/scala/Bits.scala
+++ b/src/main/scala/Bits.scala
@@ -321,6 +321,13 @@ abstract class Bits extends Data with proc {
     Bool(OUTPUT).asTypeFor(ReductionOp(this, opName))
   }
 
+  /** Allows assigning of bits to types which may convert it in colonEquals such as Flo and Dbl
+    * @example
+    * {{{
+    * val x = RegInit(Flo(0))
+    * x.equalsBits(myUInt)
+    * }}}
+    */
   def equalsBits( that : Bits ) {
     checkCompatibility(that)
     (comp match { case None => this case Some(p) => p}) procAssign that

--- a/src/main/scala/Bits.scala
+++ b/src/main/scala/Bits.scala
@@ -321,11 +321,13 @@ abstract class Bits extends Data with proc {
     Bool(OUTPUT).asTypeFor(ReductionOp(this, opName))
   }
 
-  /** Assignment operator */
-  override protected def colonEquals(that: Bits) {
+  def equalsBits( that : Bits ) {
     checkCompatibility(that)
     (comp match { case None => this case Some(p) => p}) procAssign that
   }
+
+  /** Assignment operator */
+  override protected def colonEquals(that: Bits) { equalsBits(that) }
 
   // bitwise operators
   // =================

--- a/src/test/resources/FPAssignSuite_FpAssign_1.v
+++ b/src/test/resources/FPAssignSuite_FpAssign_1.v
@@ -1,0 +1,24 @@
+module FPAssignSuite_FpAssign_1(input clk,
+    input [31:0] io_in,
+    output[31:0] io_out
+);
+
+  reg [31:0] reg_;
+
+`ifndef SYNTHESIS
+// synthesis translate_off
+  integer initvar;
+  initial begin
+    #0.002;
+    reg_ = {1{$random}};
+  end
+// synthesis translate_on
+`endif
+
+  assign io_out = reg_;
+
+  always @(posedge clk) begin
+    reg_ <= io_in;
+  end
+endmodule
+

--- a/src/test/scala/FPAssignSuite.scala
+++ b/src/test/scala/FPAssignSuite.scala
@@ -1,0 +1,32 @@
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.Ignore
+import Chisel._
+
+class FPAssignSuite extends TestSuite {
+
+  @Test def floatAssignTest {
+    class FpAssign extends Module {
+      val io = new Bundle {
+        val in = UInt(INPUT, 32)
+        val out = Flo(OUTPUT)
+      }
+      val reg = RegNext(io.in)
+      io.out.equalsBits(reg)
+    }
+
+    class FpAssignTests( c : FpAssign ) extends Tester(c) {
+      poke(c.io.in, 1056964608)
+      step(1)
+      expect(c.io.out, (0.5).toFloat)
+    }
+
+    launchCppTester( (c : FpAssign) => new FpAssignTests(c) )
+    chiselMain(Array[String]("--v",
+      "--targetDir", dir.getPath.toString()),
+      () => Module(new FpAssign()))
+    assertFile("FPAssignSuite_FpAssign_1.v")
+
+  }
+
+}


### PR DESCRIPTION
I can understand why the assignment such as from UInt to Flo may be ambiguous in that either setting the bits directly or converting the integer to a floating point number.

For the case of setting the bits directly, this is a bit painful. All that is needed is access to the Bits colonEquals however, so I added equalsBits() which is this method but not overridden.