### PR TITLE
adding cloneType override for QueueIO Bundle

### DIFF
--- a/src/main/scala/ChiselUtil.scala
+++ b/src/main/scala/ChiselUtil.scala
@@ -500,6 +500,7 @@ class QueueIO[T <: Data](gen: T, entries: Int) extends Bundle
   val deq   = Decoupled(gen.cloneType)
   /** The current amount of data in the queue */
   val count = UInt(OUTPUT, log2Up(entries + 1))
+  override def cloneType: this.type = new QueueIO(gen, entries).asInstanceOf[this.type]
 }
 
 /** A hardware module implementing a Queue

--- a/src/main/scala/ChiselUtil.scala
+++ b/src/main/scala/ChiselUtil.scala
@@ -317,6 +317,7 @@ class ArbiterIO[T <: Data](gen: T, n: Int) extends Bundle {
   val in  = Vec(n,  Decoupled(gen) ).flip
   val out = Decoupled(gen)
   val chosen = UInt(OUTPUT, log2Up(n))
+  override def cloneType: this.type = new ArbiterIO(gen, n).asInstanceOf[this.type]
 }
 
 /** Arbiter Control determining which producer has access */


### PR DESCRIPTION
I had this error in my design : 
```scala
...
[error] avlmaster.scala:279: Cannot auto-create constructor for Chisel.QueueIO that requires arguments: List(class Chisel.Data, int) in class AvlMaster.AvlMasterWriteBurst
[error] avlmaster.scala:279: Parameterized Bundle class Chisel.QueueIO needs cloneType method in class AvlMaster.AvlMasterWriteBurst
...
```
If I add an overriding cloneType function in QueueIO, this error disappear.