### PR TITLE
fsync() the memory-mapped file and verify buffer size is non-zero #624

### DIFF
--- a/src/main/resources/sim_api.h
+++ b/src/main/resources/sim_api.h
@@ -32,6 +32,7 @@ public:
     assert(fd != -1);
     assert(lseek(fd, pgsize-1, SEEK_SET) != -1);
     assert(write(fd, "", 1) != -1);
+    assert(fsync(fd) != -1);	// ensure the data is available
     channel = (char*)mmap(NULL, pgsize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0); 
     assert(channel != MAP_FAILED);
   }


### PR DESCRIPTION
Try to avoid IndexOutOfBoundsException at the start of simulation by ensuring the initial write at file creation time has been recorded, and verify that the channel file size is non-zero when we create the buffer for the memory-mapped channel.