### PR TITLE
Add fixed to list of types that are signed for peek

### DIFF
--- a/src/main/scala/Tester.scala
+++ b/src/main/scala/Tester.scala
@@ -204,7 +204,7 @@ class Tester[+T <: Module](c: T, private var isTrace: Boolean = true, _base: Int
     val w = dtype.needWidth()
     dtype match {
       /* Any "signed" node */
-      case _: SInt | _ : Flo | _: Dbl => (if(rv >= (BigInt(1) << w - 1)) (rv - (BigInt(1) << w)) else rv)
+      case _: SInt | _ : Flo | _: Dbl | _: Fixed => (if(rv >= (BigInt(1) << w - 1)) (rv - (BigInt(1) << w)) else rv)
       /* anything else (i.e., UInt) */
       case _ => (rv)
     }


### PR DESCRIPTION
Peeking on a fixed currently doesn't do the right thing for negative numbers- this should fix that.