### PR TITLE
Use long (original) signal names for comparison in VCDComparator().

### DIFF
--- a/src/test/resources/VCDVerifySuite_Top_1.vcd
+++ b/src/test/resources/VCDVerifySuite_Top_1.vcd
@@ -1,5 +1,5 @@
 $timescale 1ps $end
-$scope module VCDVerifyModule_Top_1 $end
+$scope module VCDVerifySuite_Top_1 $end
 $var wire 1 ! clk $end
 $var wire 1 " reset $end
 $var wire 1 # io_input $end


### PR DESCRIPTION
Since short names may be shuffled due to minor code changes, we should use long signal names. But these need to be qualified with the module name.
Report all disparate signals.
Use "hasNext" in place of "more" - reduce the cognitive load.
Fix initial signal set comparison.