### PR TITLE
Simplify argument handling for the Chisel3 TesterDriver.

### DIFF
--- a/src/main/scala/testers/TesterDriver.scala
+++ b/src/main/scala/testers/TesterDriver.scala
@@ -37,21 +37,12 @@ import java.io._
 
 // Wrapper to run Chisel3-style testers in Chisel2.
 
-object Chisel2State {
-  var args = Array[String]()
-}
-
-
-trait UnitTestRunners {
-}
-
 object TesterDriver {
-  def execute(t: () => BasicTester)(implicit optionArgs: Array[String]): Boolean = {
-    Chisel2State.args = optionArgs
+  def execute(t: () => BasicTester)(implicit testArgs: Array[String]): Boolean = {
     try {
       // Construct the combined circuit, containing all the required
       //  poke()'s and expect()'s as arrays of data.
-      val mod = Driver(Chisel2State.args, finishWrapper(t), false)
+      val mod = Driver(testArgs, finishWrapper(t), false)
       if (Driver.isTesting) {
         // Initialize a tester with tracing turned on.
         val c = new Tester(mod, true)
@@ -77,10 +68,8 @@ object TesterDriver {
     }
   }
 
-  def elaborate(t: () => BasicTester): Module = {
-    val removeArgs = Array("--compile", "--test", "--genHarness")
-    val filteredArgs = Chisel2State.args.filterNot(removeArgs.contains(_))
-    val mod = Driver(filteredArgs ++ Array("--compile", "--genHarness"), finishWrapper(t), false)
+  def elaborate(t: () => BasicTester)(implicit testArgs: Array[String]): Module = {
+    val mod = Driver(testArgs, finishWrapper(t), false)
     mod
   }
 

--- a/src/test/scala/DecoupledGCD.scala
+++ b/src/test/scala/DecoupledGCD.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011 - 2015 The Regents of the University of
+ Copyright (c) 2011 - 2016 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:
@@ -33,6 +33,7 @@ import Chisel.testers.{TesterDriver, SteppedHWIOTester, OrderedDecoupledHWIOTest
 import org.junit.Assert._
 import org.junit.Test
 import org.junit.Ignore
+import TestHelpers._
 
 object GCDCalculator {
   def computeGcdResultsAndCycles(a: Int, b: Int, depth: Int = 1): (Int, Int) = {
@@ -92,25 +93,6 @@ class GCDDecoupledTest extends TestSuite {
       p := Bool(false)
     }
   }
-  
-  
-  
-  //class DecoupledRealGCDTester extends DecoupledTester {
-  //  val device_under_test = Module(new RealGCD)
-  //  val c = device_under_test // alias for dut
-  //
-  //  for(x <- 0 until 9) {
-  //    event(
-  //      Array(
-  //        c.io.in.bits.a -> 14,
-  //        c.io.in.bits.b -> 35
-  //      ),
-  //      Array(c.io.out.bits -> 7)
-  //    )
-  //  }
-  //  finish()
-  //  io_info.show_ports("".r)
-  //}
   
   class RealGCDTests extends SteppedHWIOTester {
     val device_under_test = Module( new RealGCD )
@@ -198,7 +180,7 @@ class GCDDecoupledTest extends TestSuite {
     }
   }
   
-  implicit val args = Array[String]("--backend", "c", "--compile", "--genHarness", "--test")
+  implicit val args = Array[String]("--backend", "c", "--compile", "--genHarness", "--test", "--targetDir", TestHelpers.dir.getPath.toString())
   TesterDriver.execute { () => new DecoupledRealGCDTests4 }
  }
 }

--- a/src/test/scala/GCDUnitTest.scala
+++ b/src/test/scala/GCDUnitTest.scala
@@ -1,5 +1,5 @@
 /*
- Copyright (c) 2011 - 2015 The Regents of the University of
+ Copyright (c) 2011 - 2016 The Regents of the University of
  California (Regents). All Rights Reserved.  Redistribution and use in
  source and binary forms, with or without modification, are permitted
  provided that the following conditions are met:
@@ -33,6 +33,7 @@ import Chisel.testers.{TesterDriver, SteppedHWIOTester}
 import org.junit.Assert._
 import org.junit.Test
 import org.junit.Ignore
+import TestHelpers._
 
 // Test the Chisel3 UnitTester interface.
 
@@ -100,7 +101,7 @@ class GCDUnitTest extends TestSuite {
     }
   }
   
-  implicit val args = Array[String]("--backend", "c", "--compile", "--genHarness", "--test")
+  implicit val args = Array[String]("--backend", "c", "--compile", "--genHarness", "--test", "--targetDir", TestHelpers.dir.getPath.toString())
   TesterDriver.execute { () => new GCDUnitTester }
  }
 }

--- a/src/test/scala/TestSuite.scala
+++ b/src/test/scala/TestSuite.scala
@@ -44,7 +44,7 @@ object TestSuite {
 }
 
 abstract class TestSuite extends JUnitSuite with TestHelpers {
-  // This functionality has been replace by the static TestHelper object
+  // This functionality has been replaced by the static TestHelper object
   //  and should be elminated.
   @Before def initialize() {
   }


### PR DESCRIPTION
Update copyright date; specify targetDir.