### PR TITLE
Don't initialize the channels until we know how big they need to be - #655

### DIFF
--- a/src/main/resources/sim_api.h
+++ b/src/main/resources/sim_api.h
@@ -18,6 +18,9 @@
 #include <time.h>
 
 enum SIM_CMD { RESET, STEP, UPDATE, POKE, PEEK, FORCE, GETID, GETCHK, SETCLK, FIN };
+const int SIM_CMD_MAX_BYTES = 1024;
+const int channel_data_offset_64bw = 4;		// Offset from start of channel buffer to actual user data in 64bit words.
+static size_t gSystemPageSize;
 
 template<class T> struct sim_data_t {
   std::vector<T> resets;
@@ -26,15 +29,28 @@ template<class T> struct sim_data_t {
   std::vector<T> signals;
   std::map<std::string, size_t> signal_map;
   std::map<std::string, T> clk_map;
+  // Calculate the size (in bytes) of data stored in a vector.
+  size_t storage_size(const std::vector<T> vec) {
+    int nitems = vec.size();
+#ifdef VPI_USER_H
+    return nitems * sizeof(T);
+#else
+    size_t result = 0;
+    for (int i = 0; i < nitems; i++) {
+      result += vec[i]->get_num_words();
+    }
+    return result * sizeof(val_t);
+#endif
+  }
 };
 
 class channel_t {
 public:
+#define ROUND_UP(N, S) ((((N) + (S) -1 ) & (~((S) - 1))))
   void init_map() {
 	static std::string m_prefix("channel_t::init_map - ");
-    uintptr_t pgsize = sysconf(_SC_PAGESIZE);
 	// ensure the data is available (a full page worth).
-    if (lseek(fd, pgsize-1, SEEK_SET) == -1) {
+    if (lseek(fd, map_size-1, SEEK_SET) == -1) {
     	perror((m_prefix + "file: " + full_file_path + " seek to end of page").c_str());
     	exit(1);
     }
@@ -46,13 +62,14 @@ public:
     	perror((m_prefix + "file: " + full_file_path + " fsync").c_str());
     	exit(1);
     }
-    channel = (char*)mmap(NULL, pgsize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0); 
+    channel = (char*)mmap(NULL, map_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     if (channel == MAP_FAILED) {
     	perror((m_prefix + "file: " + full_file_path + " mmap").c_str());
     	exit(1);
     }
   }
-  channel_t(std::string _file_name): file_name(_file_name), fd(open(file_name.c_str(),  O_RDWR|O_CREAT|O_TRUNC, (mode_t)0600)) {
+  channel_t(std::string _file_name, size_t _data_size): file_name(_file_name), fd(open(file_name.c_str(),  O_RDWR|O_CREAT|O_TRUNC, (mode_t)0600)),
+		  map_size(ROUND_UP(_data_size + channel_data_offset_64bw * 8, gSystemPageSize)) {
 	static std::string m_prefix("channel_t::channel_t: ");
     char * rp = realpath(file_name.c_str(), NULL);
     full_file_path = std::string(rp == NULL ? file_name : rp);
@@ -68,8 +85,7 @@ public:
   }
 
   ~channel_t() {
-    uintptr_t pgsize = sysconf(_SC_PAGESIZE);
-    munmap((void *)channel, pgsize);
+    munmap((void *)channel, map_size);
     close(fd);
   }
   inline void aquire() {
@@ -82,8 +98,8 @@ public:
   inline void consume() { channel[3] = 0; }
   inline bool ready() { return channel[3] == 0; }
   inline bool valid() { return channel[3] == 1; }
-  inline uint64_t* data() { return (uint64_t*)(channel+4); }
-  inline char* str() { return ((char *)channel+4); }
+  inline uint64_t* data() { return (uint64_t*)(channel + channel_data_offset_64bw); }
+  inline char* str() { return ((char *)channel + channel_data_offset_64bw); }
   inline uint64_t& operator[](int i) { return data()[i*sizeof(uint64_t)]; }
 private:
   // Dekker's alg for sync
@@ -96,19 +112,29 @@ private:
   const std::string file_name;
   std::string full_file_path;
   const int fd;
+  const size_t map_size;
 };
 
 template <class T> class sim_api_t {
 public:
   sim_api_t() {
+    // This is horrible, but we'd rather not have to generate another .cpp initialization file,
+    //  and have all our clients update their Makefiles (if they don't use ours) to build the simulator.
+    if (gSystemPageSize == 0) {
+      gSystemPageSize = sysconf(_SC_PAGESIZE);
+    }
+  }
+  void init_channels() {
     pid_t pid = getpid();
     std::ostringstream in_ch_name, out_ch_name, cmd_ch_name;
     in_ch_name  << std::dec << std::setw(8) << std::setfill('0') << pid << ".in";
     out_ch_name << std::dec << std::setw(8) << std::setfill('0') << pid << ".out";
     cmd_ch_name << std::dec << std::setw(8) << std::setfill('0') << pid << ".cmd";
-    in_channel  = new channel_t(in_ch_name.str());
-    out_channel = new channel_t(out_ch_name.str());
-    cmd_channel = new channel_t(cmd_ch_name.str());
+    size_t input_size = this->sim_data.storage_size(this->sim_data.inputs);
+    in_channel  = new channel_t(in_ch_name.str(), input_size);
+    size_t output_size = this->sim_data.storage_size(this->sim_data.outputs);
+    out_channel = new channel_t(out_ch_name.str(), output_size);
+    cmd_channel = new channel_t(cmd_ch_name.str(), SIM_CMD_MAX_BYTES);
     
     // Init channels
     out_channel->consume();
@@ -168,6 +194,7 @@ public:
       }
     } while (!exit);
   }
+
 private:
   channel_t *in_channel;
   channel_t *out_channel;

--- a/src/main/resources/vpi.cpp
+++ b/src/main/resources/vpi.cpp
@@ -26,6 +26,7 @@ PLI_INT32 init_outs_calltf(PLI_BYTE8 *user_data) {
 
 PLI_INT32 init_sigs_calltf(PLI_BYTE8 *user_data) {
   vpi_api->init_sigs();
+  vpi_api->init_channels();
   return 0;
 }
 

--- a/src/main/scala/Cpp.scala
+++ b/src/main/scala/Cpp.scala
@@ -750,6 +750,7 @@ class CppBackend extends Backend {
     harness.write(s"""  ${name}_api_t api(&module);\n""")
     harness.write(s"""  module.init();\n""")
     harness.write(s"""  api.init_sim_data();\n""")
+    harness.write(s"""  api.init_channels();\n""")
     if (Driver.isVCD) {
       harness.write(s"""  FILE *f = fopen("${Driver.targetDir}/${name}.vcd", "w");\n""")
     } else {

--- a/src/main/scala/Tester.scala
+++ b/src/main/scala/Tester.scala
@@ -162,6 +162,7 @@ class Tester[+T <: Module](c: T, private var isTrace: Boolean = true, _base: Int
       channel map (FileChannel.MapMode.READ_WRITE, 0, size)
     }
     implicit def intToByte(i: Int) = i.toByte
+    val channel_data_offset_64bw = 4    // Offset from start of channel buffer to actual user data in 64bit words.
     def aquire {
       buffer put (0, 1)
       buffer put (2, 0)
@@ -172,12 +173,12 @@ class Tester[+T <: Module](c: T, private var isTrace: Boolean = true, _base: Int
     def valid = (buffer get 3) == 1
     def produce { buffer put (3, 1) }
     def consume { buffer put (3, 0) }
-    def update(idx: Int, data: Long) { buffer putLong (8 * idx + 4, data) }
+    def update(idx: Int, data: Long) { buffer putLong (8 * idx + channel_data_offset_64bw, data) }
     def update(base: Int, data: String) {
-      data.zipWithIndex foreach {case (c, i) => buffer put (base + i + 4, c) }
-      buffer put (base + data.size + 4, 0)
+      data.zipWithIndex foreach {case (c, i) => buffer put (base + i + channel_data_offset_64bw, c) }
+      buffer put (base + data.size + channel_data_offset_64bw, 0)
     }
-    def apply(idx: Int): Long = buffer getLong (8 * idx + 4)
+    def apply(idx: Int): Long = buffer getLong (8 * idx + channel_data_offset_64bw)
     def close { file.close }
     buffer order java.nio.ByteOrder.nativeOrder
     new java.io.File(name).delete

--- a/src/test/scala/TesterTest.scala
+++ b/src/test/scala/TesterTest.scala
@@ -47,9 +47,8 @@ import Chisel.AdvTester._
 // scalastyle:off method.length
 
 class TesterTest extends TestSuite {
-  val testArgs = Array("--backend", "v",
-      "--targetDir", dir.getPath.toString()
-      )
+
+  val backends = List("c") ++ {if (Driver.isVCSAvailable) "v" :: Nil else Nil}
 
   /** Test poking various numbers.
    *  This is primarily a test of the Tester and its peek/poke/expect interface.
@@ -128,9 +127,11 @@ class TesterTest extends TestSuite {
       tests(m)
     }
 
-    chiselMainTest(Array[String]("--backend", "c",
-      "--targetDir", dir.getPath.toString(), "--genHarness", "--compile", "--test"),
-      () => Module(new IOSelector())) {m => new VariousPokeTester(m)}
+    for (b <- backends) {
+      chiselMainTest(Array[String]("--backend", b,
+        "--targetDir", dir.getPath.toString(), "--genHarness", "--compile", "--test"),
+        () => Module(new IOSelector())) {m => new VariousPokeTester(m)}
+    }
   }
 
   /** Test poking negative numbers.
@@ -161,9 +162,11 @@ class TesterTest extends TestSuite {
       expect(c.io.o_value, -1L )
     }
 
-    chiselMainTest(Array[String]("--backend", "c",
-      "--targetDir", dir.getPath.toString(), "--genHarness", "--compile", "--test"),
-      () => Module(new PokeNegModule())) {m => new PokeNegTests(m)}
+    for (b <- backends) {
+      chiselMainTest(Array[String]("--backend", b,
+        "--targetDir", dir.getPath.toString(), "--genHarness", "--compile", "--test"),
+        () => Module(new PokeNegModule())) {m => new PokeNegTests(m)}
+    }
   }
 
   /** Test poking wide numbers.
@@ -173,44 +176,82 @@ class TesterTest extends TestSuite {
   @Test def testPokeWide () {
     println("\ntestPokeWide ...")
 
-    // We'd like to use something like assume() here, but it generates
-    // a TestCanceledException. There should be a programmatic way to skip
-    // tests (without failing) but make a note of the fact.
-    if (!Driver.isVCSAvailable) {
-      assert(true, "vcs unavailable - skipping testPokeWide")
-    } else {
-      class PokeWideModule extends Module {
+    class PokeWideModule extends Module {
 
-        val io = new Bundle {
-          val i_value     = UInt(INPUT, width = 64)
-          val o_value     = UInt(OUTPUT, width = 64)
-        }
-
-        io.o_value := io.i_value
+      val io = new Bundle {
+        val i_value     = UInt(INPUT, width = 64)
+        val o_value     = UInt(OUTPUT, width = 64)
       }
 
-      class PokeWideTests(c:PokeWideModule) extends AdvTester(c, true){
-        wire_poke(c.io.i_value, 0x7100a000a000a000L)
-        expect(c.io.o_value, 0x7100a000a000a000L)
+      io.o_value := io.i_value
+    }
 
-        // We need to construct the next number carefully.
-        //  We don't want it flagged as a negative number,
-        //  so we manually construct it by shifting a positive number.
-        //  (0x8100a000a000a000L is interpreted as a negative 64-bit number.
-        val notNeg = BigInt(0x8100a000a000a00L) << 4
-        wire_poke(c.io.i_value, notNeg)
-        expect(c.io.o_value, notNeg)
+    class PokeWideTests(c:PokeWideModule) extends AdvTester(c, true){
+      wire_poke(c.io.i_value, 0x7100a000a000a000L)
+      expect(c.io.o_value, 0x7100a000a000a000L)
 
-        // "-1" is not a legal poke value for the Verilog tester..
-        // All poke values must be hex strings for Verilog.
-        // See harnessAPIs() in Verilog.scala
-        //wire_poke(c.io.i_value, -1L )
-        //expect(c.io.o_value, -1L )
-      }
+      // We need to construct the next number carefully.
+      //  We don't want it flagged as a negative number,
+      //  so we manually construct it by shifting a positive number.
+      //  (0x8100a000a000a000L is interpreted as a negative 64-bit number.
+      val notNeg = BigInt(0x8100a000a000a00L) << 4
+      wire_poke(c.io.i_value, notNeg)
+      expect(c.io.o_value, notNeg)
 
-      chiselMainTest(Array[String]("--backend", "v",
+      // "-1" is not a legal poke value for the Verilog tester..
+      // All poke values must be hex strings for Verilog.
+      // See harnessAPIs() in Verilog.scala
+      //wire_poke(c.io.i_value, -1L )
+      //expect(c.io.o_value, -1L )
+    }
+
+    for (b <- backends) {
+      chiselMainTest(Array[String]("--backend", b,
         "--targetDir", dir.getPath.toString(), "--genHarness", "--compile", "--test"),
         () => Module(new PokeWideModule())) {m => new PokeWideTests(m)}
+    }
+  }
+
+  /** Test many IOs - issue #665.
+   *  This is primarily a test of the Tester and its peek/poke/expect interface.
+   *
+   */
+  @Test def testBigIO () {
+    println("\ntestBiGIO ...")
+
+    class PokeBigIOModule extends Module {
+
+      val io = new Bundle {
+        val i_values     = Vec(8192, UInt(INPUT, width = 64))
+        val o_values     = Vec(10000, UInt(OUTPUT, width = 64))
+      }
+
+      io.o_values(9000) := io.i_values(8191)
+    }
+
+    class PokeBigIOTests(c:PokeBigIOModule) extends AdvTester(c, true){
+      wire_poke(c.io.i_values(8191), 0x7100a000a000a000L)
+      expect(c.io.o_values(9000), 0x7100a000a000a000L)
+
+      // We need to construct the next number carefully.
+      //  We don't want it flagged as a negative number,
+      //  so we manually construct it by shifting a positive number.
+      //  (0x8100a000a000a000L is interpreted as a negative 64-bit number.
+      val notNeg = BigInt(0x8100a000a000a00L) << 4
+      wire_poke(c.io.i_values(8191), notNeg)
+      expect(c.io.o_values(9000), notNeg)
+
+      // "-1" is not a legal poke value for the Verilog tester..
+      // All poke values must be hex strings for Verilog.
+      // See harnessAPIs() in Verilog.scala
+      //wire_poke(c.io.i_value, -1L )
+      //expect(c.io.o_value, -1L )
+    }
+
+    for (b <- backends) {
+      chiselMainTest(Array[String]("--backend", b,
+        "--targetDir", dir.getPath.toString(), "--genHarness", "--compile", "--test"),
+        () => Module(new PokeBigIOModule())) {m => new PokeBigIOTests(m)}
     }
   }
 }


### PR DESCRIPTION
NOTE - This requires a new init_channels() method which must be called after init_sim_data().
Use symbolic constants in Tester.scala and sim_api.h for the channel data offset.
Run TesterTests with both C++ and Verilog backends (if the latter is available).
Add a test for dynamically sized channel code.

Update vcs support for big IOs.