### PR TITLE
Fix broken printf, newTestOutputString called multiple times

### DIFF
--- a/src/main/scala/Tester.scala
+++ b/src/main/scala/Tester.scala
@@ -73,7 +73,7 @@ trait Tests {
   def expect (data: Bool, expected: Boolean): Boolean
   def expect (data: Flo, expected: Float): Boolean
   def expect (data: Dbl, expected: Double): Boolean
-  def newTestOutputString: String
+  def outputString: String
   def expect (data: Bits, expected: BigInt, msg: => String): Boolean
   def expect (data: Bits, expected: Int, msg: => String): Boolean
   def expect (data: Bits, expected: Long, msg: => String): Boolean
@@ -107,10 +107,12 @@ class Tester[+T <: Module](c: T, private var isTrace: Boolean = true, _base: Int
   private var isStale = false
   // Return any accumulated module printf output since the last call.
   private var _lastLogIndex = 0
-  def newTestOutputString: String = {
-    val result = _logs.slice(_lastLogIndex, _logs.length) mkString("\n")
+  private var _outputString = ""
+  def outputString : String = _outputString
+  private def newTestOutputString : String = {
+    _outputString = _logs.slice(_lastLogIndex, _logs.length) mkString("\n")
     _lastLogIndex = _logs.length
-    result
+    _outputString
   }
   private val _logs = new ArrayBuffer[String]()
   def printfs = _logs.toVector
@@ -499,7 +501,7 @@ class Tester[+T <: Module](c: T, private var isTrace: Boolean = true, _base: Int
     delta += calcDelta
     mwhile(!recvOutputs) { }
     // dumpLogs
-    if (isTrace && newTestOutputString != "") println(newTestOutputString)
+    if (isTrace && newTestOutputString != "") println(outputString)
     isStale = false
   }
 

--- a/src/test/scala/FlushPrintfOutput.scala
+++ b/src/test/scala/FlushPrintfOutput.scala
@@ -73,18 +73,17 @@ class FlushPrintfOutput extends TestSuite {
   // TODO: better way to check logs? logging is lower than tests, so it sometimes fails...
   trait FlushPrintfOutputTests extends Tests {
     val expectedOutputs = collection.mutable.ArrayBuffer[String]()
+    val outputs = collection.mutable.ArrayBuffer[String]()
     def tests(m: BasePrintfModule) {
       for (i <- 0 until 4) {
         step(1)
+        outputs += outputString
         if (m.isFloat) {
           expectedOutputs += m.counterString.format(i.toFloat)
         } else {
           expectedOutputs += m.counterString.format(i)
         }
       }
-      // Wait for any delayed output to accumulate
-      Thread.sleep(200)
-      val outputs = printfs
       assertResult(true, "incorrect number of outputs - %s".format(outputs)) {
         outputs.length == expectedOutputs.length
       }


### PR DESCRIPTION
Just realized I broke printf in #640 
Multiple calls to newTestOutputString resulted in empty string being printed
Added function outputString() which returns the output string for the current step
Made newTestOutputString private
Used outputString directly in flushPrintfOutput suite
Removed the Thread.sleep because if there is an issue as alluded to in the comment, this will mean the printfs are out of order compared to the steps