### PR TITLE
Corrected bit width of indexes into wires in verilog

### DIFF
--- a/src/main/scala/Node.scala
+++ b/src/main/scala/Node.scala
@@ -502,6 +502,10 @@ abstract class Node extends Nameable {
     * @throws ChiselException if the width is not yet defined
     */
   def needWidth(): Int = widthW.needWidth
+  /** Get the with needed to index into this Node
+    * @return an "known" integer value, log_2(needWidth()) rounded up
+    * @throws NoSuchElementException if called when the width is unknown */
+  lazy val extractionWidth: Int = scala.math.ceil(scala.math.log(needWidth())/scala.math.log(2)).toInt
   /** Return true if the width of this node is known (set). */
   private[Chisel] def isKnownWidth: Boolean = widthW.isKnown
 

--- a/src/test/resources/DelaySuite_MemReadModule_1.v
+++ b/src/test/resources/DelaySuite_MemReadModule_1.v
@@ -20,6 +20,6 @@ module DelaySuite_MemReadModule_1(input clk,
 
   assign io_out = T0;
   assign T0 = mem[T1];
-  assign T1 = io_addr[2'h2:1'h0];
+  assign T1 = io_addr[5'h2:5'h0];
 endmodule
 

--- a/src/test/resources/DelaySuite_ReadCondMaskedWrite_1.v
+++ b/src/test/resources/DelaySuite_ReadCondMaskedWrite_1.v
@@ -29,8 +29,8 @@ module DelaySuite_ReadCondMaskedWrite_1(input clk,
   assign T2 = T4 | T3;
   assign T3 = T0 & 32'hff;
   assign T4 = T0 & 32'hff00;
-  assign T5 = io_addr[2'h2:1'h0];
-  assign T6 = io_addr[2'h2:1'h0];
+  assign T5 = io_addr[5'h2:5'h0];
+  assign T6 = io_addr[5'h2:5'h0];
 
   always @(posedge clk) begin
     if (io_enable)

--- a/src/test/resources/DelaySuite_ReadCondWriteModule_1.v
+++ b/src/test/resources/DelaySuite_ReadCondWriteModule_1.v
@@ -31,13 +31,13 @@ module DelaySuite_ReadCondWriteModule_1(input clk,
   assign io_out = T0;
   assign T0 = mem[T10];
   assign T2 = mem[T7];
-  assign T7 = T3[2'h2:1'h0];
+  assign T7 = T3[5'h2:5'h0];
   assign T3 = io_addr + 32'h4;
   assign T4 = io_enable ^ 1'h1;
-  assign T8 = io_addr[2'h2:1'h0];
+  assign T8 = io_addr[5'h2:5'h0];
   assign T6 = T0 + 32'h1;
-  assign T9 = io_addr[2'h2:1'h0];
-  assign T10 = io_addr[2'h2:1'h0];
+  assign T9 = io_addr[5'h2:5'h0];
+  assign T10 = io_addr[5'h2:5'h0];
 
   always @(posedge clk) begin
     if (T4)

--- a/src/test/resources/DelaySuite_ReadWriteModule_1.v
+++ b/src/test/resources/DelaySuite_ReadWriteModule_1.v
@@ -24,8 +24,8 @@ module DelaySuite_ReadWriteModule_1(input clk,
   assign io_out = T0;
   assign T0 = mem[T4];
   assign T2 = T0 + 32'h1;
-  assign T3 = io_addr[2'h2:1'h0];
-  assign T4 = io_addr[2'h2:1'h0];
+  assign T3 = io_addr[5'h2:5'h0];
+  assign T4 = io_addr[5'h2:5'h0];
 
   always @(posedge clk) begin
     if (1'h1)

--- a/src/test/resources/NameSuite_BindFifthComp_1.v
+++ b/src/test/resources/NameSuite_BindFifthComp_1.v
@@ -48,12 +48,12 @@ module NameSuite_Block_2(input clk,
   assign T4 = T5[1'h1];
   assign T5 = 1'h1 << T6;
   assign T6 = 1'h0;
-  assign T7 = tag_ram_0[1'h1];
+  assign T7 = tag_ram_0[5'h1];
   assign T8 = T9 ? io_in_resp_bits_ppn : tag_ram_0;
   assign T9 = io_in_resp_valid & T10;
   assign T10 = T5[1'h0];
   assign T11 = T12 ? tag_ram_0 : 32'h0;
-  assign T12 = tag_ram_0[1'h0];
+  assign T12 = tag_ram_0[5'h0];
 
   always @(posedge clk) begin
     if(T3) begin

--- a/src/test/resources/NameSuite_VecComp_1.v
+++ b/src/test/resources/NameSuite_VecComp_1.v
@@ -27,7 +27,7 @@ module NameSuite_VecComp_1(input clk,
 `endif
 
   assign io_status_im = reg_status_im;
-  assign T0 = wdata[3'h7:1'h0];
+  assign T0 = wdata[6'h7:6'h0];
   assign wdata = io_r_en ? io_w_data : host_pcr_bits_data;
   assign T1 = io_r_en ? T2 : host_pcr_bits_data;
   assign T2 = {56'h0, rdata};

--- a/src/test/resources/StdlibSuite_OHToUIntComp_1.v
+++ b/src/test/resources/StdlibSuite_OHToUIntComp_1.v
@@ -19,7 +19,7 @@ module StdlibSuite_OHToUIntComp_1(
   assign T5 = {T10, T6};
   assign T6 = T7[1'h1];
   assign T7 = T9 | T8;
-  assign T8 = T1[1'h1:1'h0];
+  assign T8 = T1[2'h1:2'h0];
   assign T1 = T2;
   assign T2 = {T4, T3};
   assign T3 = {io_in, 1'h1};


### PR DESCRIPTION
Currently, verilog generated by CHISEL explicitly sets the width of bits used to index into wires/registers. 

However, rather than the bit width of the index being set by the width of the wire being indexed into, the bit width is simply set to the minimum that it needs to be in order to hold the index number.

for example:
wire io_addr[31:0]
assign T5 = io_addr[2'h2:1'h0]; // <= should be [5'h2 : 5'h0]   OR ['h2 : 'h0] OR [2 : 0]

Note that there are actually three ways the issue could be solved:

1. Do not explicitly set bit widths of indices  ('h2 instead of 2'h2)
2. Use base-10 numbers (2 instead of 2'h2)
3. Use the proper bit-withs, log_2(with_of_wire), rounded up.

This pull request fixes the issue by using option number 3, simply using the correct bit-widths. However, there is no reason we need to explicitly set a width at all.

I am submitting this pull request for now, but if anyone thinks that solving the issue using options 1 or 2 would be better, I am completely willing to redo the changes in either way.

see also:
[https://github.com/ucb-bar/chisel/pull/681](https://github.com/ucb-bar/chisel/pull/681)

only either this (hex) or the other (base 10) should be accepted