### PR TITLE
do not extract a single bit wire

### DIFF
--- a/src/main/scala/Verilog.scala
+++ b/src/main/scala/Verilog.scala
@@ -258,6 +258,10 @@ class VerilogBackend extends Backend {
           if (x.isNop) {
             source
           } else
+          // Is source a single bit? - no need to extract
+            if (node.inputs(0).needWidth == 1) {
+            source
+          } else
           // Is this a single bit extraction?
             if (x.isOneBit) {
             List(source, "[", hi, "]").mkString


### PR DESCRIPTION
This fixes complaints in fpga synthesis due to extractions from single bit wires.