### PR TITLE
Fix memory access masking bug for nonPow2 memories

### DIFF
--- a/src/main/resources/emulator.h
+++ b/src/main/resources/emulator.h
@@ -1549,7 +1549,7 @@ class mem_t {
   }
   val_t get (val_t idx, int word) {
     if (/*!ispow2(d) &&*/ idx >= d)
-      return __rand_val(seedp) & (word == val_n_words(w) && val_n_word_bits(w) ? mask_val(w) : -1L);
+      return __rand_val(seedp) & (((word+1) == val_n_words(w) && val_n_word_bits(w)) ? mask_val(w) : -1L);
     return contents[idx].values[word];
   }
 

--- a/src/main/resources/emulator.h
+++ b/src/main/resources/emulator.h
@@ -1549,7 +1549,7 @@ class mem_t {
   }
   val_t get (val_t idx, int word) {
     if (/*!ispow2(d) &&*/ idx >= d)
-      return __rand_val(seedp) & (((word+1) == val_n_words(w) && val_n_word_bits(w)) ? mask_val(w) : -1L);
+      return __rand_val(seedp) & ((word == val_n_full_words(w) && val_n_word_bits(w)) ? mask_val(w) : -1L);
     return contents[idx].values[word];
   }
 


### PR DESCRIPTION
I've found that for a NonPow2 sized memory, I was getting garbage values that were causing buffer overruns elsewhere in my Chisel emulator (feeding a mem.read() value into another mem() access). 

I'd like a code review to verify my logic on this is correct.