### PR TITLE
Improve log2* functions, as with Chisel3

### DIFF
--- a/src/main/scala/ChiselUtil.scala
+++ b/src/main/scala/ChiselUtil.scala
@@ -33,33 +33,39 @@ import scala.math.{ceil, floor, log}
 import scala.collection.mutable.ArrayBuffer
 
 /** Compute the log2 rounded up with min value of 1 */
-object log2Up
-{
-  def apply(in: Int): Int = if(in == 1) 1 else ceil(log(in)/log(2)).toInt
+object log2Up {
+  def apply(in: BigInt): Int = {
+    require(in >= 0)
+    1 max (in-1).bitLength
+  }
+  def apply(in: Int): Int = apply(BigInt(in))
 }
 
 /** Compute the log2 rounded up */
-object log2Ceil
-{
-  def apply(in: Int): Int = ceil(log(in)/log(2)).toInt
+object log2Ceil {
+  def apply(in: BigInt): Int = {
+    require(in > 0)
+    (in-1).bitLength
+  }
+  def apply(in: Int): Int = apply(BigInt(in))
 }
 
 /** Compute the log2 rounded down with min value of 1 */
-object log2Down
-{
-  def apply(x : Int): Int = if (x == 1) 1 else floor(log(x)/log(2.0)).toInt
+object log2Down {
+  def apply(in: BigInt): Int = log2Up(in) - (if (isPow2(in)) 0 else 1)
+  def apply(in: Int): Int = apply(BigInt(in))
 }
 
 /** Compute the log2 rounded down */
-object log2Floor
-{
-  def apply(x : Int): Int = floor(log(x)/log(2.0)).toInt
+object log2Floor {
+  def apply(in: BigInt): Int = log2Ceil(in) - (if (isPow2(in)) 0 else 1)
+  def apply(in: Int): Int = apply(BigInt(in))
 }
 
 /** Check if an Integer is a power of 2 */
-object isPow2
-{
-  def apply(in: Int): Boolean = in > 0 && ((in & (in-1)) == 0)
+object isPow2 {
+  def apply(in: BigInt): Boolean = in > 0 && ((in & (in-1)) == 0)
+  def apply(in: Int): Boolean = apply(BigInt(in))
 }
 
 /** Fold Right with a function */


### PR DESCRIPTION
The previous ones were incorrect for large inputs because of inexact
floating-point arithmetic.  These use BigInt so are exact.  This also
fixes log2Up(0) to conform to the documentation.