### PR TITLE
add package object with new literal creation implicits

### DIFF
--- a/src/main/scala/package.scala
+++ b/src/main/scala/package.scala
@@ -1,0 +1,17 @@
+package object Chisel {
+  import Chisel.Width
+  implicit class fromBigIntToLiteral(val x: BigInt) extends AnyVal {
+    def U: UInt = UInt(x)
+    def S: SInt = SInt(x)
+  }
+  implicit class fromIntToLiteral(val x: Int) extends AnyVal {
+    def U: UInt = UInt(BigInt(x))
+    def S: SInt = SInt(BigInt(x))
+  }
+  implicit class fromStringToLiteral(val x: String) extends AnyVal {
+    def U: UInt = UInt(x)
+  }
+  implicit class fromBooleanToLiteral(val x: Boolean) extends AnyVal {
+    def B: Bool = Bool(x)
+  }
+}

--- a/src/test/scala/ArbiterTest.scala
+++ b/src/test/scala/ArbiterTest.scala
@@ -238,8 +238,8 @@ class ArbiterSuite extends TestSuite {
 
   @Test def testLockingArbiter() {
 
-    //def hasDat(d: UInt):Bool = d === UInt(0)
-    class MyLockingArbiter extends LockingArbiter[UInt](UInt(width=4), 4, 2, Some((d:UInt) => d === UInt(0)))
+    //def hasDat(d: UInt):Bool = d === 0.U
+    class MyLockingArbiter extends LockingArbiter[UInt](UInt(width=4), 4, 2, Some((d:UInt) => d === 0.U))
 
     class ArbiterTests(c: MyLockingArbiter) extends Tester(c) {
 
@@ -290,8 +290,8 @@ class ArbiterSuite extends TestSuite {
 
   @Test def testStableLockingArbiter() {
 
-    //def hasDat(d: UInt):Bool = d === UInt(0)
-    class MyStableLockingArbiter extends LockingArbiter[UInt](UInt(width=4), 4, 2, Some((d:UInt) => d === UInt(0)), true)
+    //def hasDat(d: UInt):Bool = d === 0.U
+    class MyStableLockingArbiter extends LockingArbiter[UInt](UInt(width=4), 4, 2, Some((d:UInt) => d === 0.U), true)
 
     class ArbiterTests(c: MyStableLockingArbiter) extends Tester(c) {
 
@@ -542,8 +542,8 @@ class ArbiterSuite extends TestSuite {
 
   @Test def testRRLockingArbiter() {
 
-    //def hasDat(d: UInt):Bool = d === UInt(0)
-    class MyRRLockingArbiter extends LockingRRArbiter[UInt](UInt(width=4), 4, 2, Some((d:UInt) => d === UInt(3)))
+    //def hasDat(d: UInt):Bool = d === 0.U
+    class MyRRLockingArbiter extends LockingRRArbiter[UInt](UInt(width=4), 4, 2, Some((d:UInt) => d === 3.U))
 
     class ArbiterTests(c: MyRRLockingArbiter) extends Tester(c) {
 
@@ -594,8 +594,8 @@ class ArbiterSuite extends TestSuite {
 
   @Test def testStableRRLockingArbiter() {
 
-    //def hasDat(d: UInt):Bool = d === UInt(0)
-    class MyStableRRLockingArbiter extends LockingRRArbiter[UInt](UInt(width=4), 4, 2, Some((d:UInt) => d === UInt(3)), true)
+    //def hasDat(d: UInt):Bool = d === 0.U
+    class MyStableRRLockingArbiter extends LockingRRArbiter[UInt](UInt(width=4), 4, 2, Some((d:UInt) => d === 3.U), true)
 
     class ArbiterTests(c: MyStableRRLockingArbiter) extends Tester(c) {
 

--- a/src/test/scala/AssertSuite.scala
+++ b/src/test/scala/AssertSuite.scala
@@ -57,7 +57,7 @@ class AssertSuite extends TestSuite with ShouldMatchers {
 
   @Test def testRTAssert() {
     println("\ntestRTAssert...")
-    val assertMessage = "io.dataIn == UInt(8)"
+    val assertMessage = "io.dataIn == 8.U"
     class mkAssert extends Module{
       val io = new Bundle{
         val dataIn = UInt(INPUT,8)
@@ -65,7 +65,7 @@ class AssertSuite extends TestSuite with ShouldMatchers {
       }
 
       io.dataOut := OHToUInt(io.dataIn)
-      assert(io.dataIn =/= UInt(8), assertMessage)
+      assert(io.dataIn =/= 8.U, assertMessage)
     }
 
     class TBAssert(c: mkAssert) extends Tester(c) {

--- a/src/test/scala/BitPatSuite.scala
+++ b/src/test/scala/BitPatSuite.scala
@@ -45,7 +45,7 @@ class BitPatSuite extends TestSuite {
       }
       io.out := Bool(false)
       switch(io.in) {
-        is(UInt(0)) { io.out := Bool(true) }
+        is(0.U) { io.out := Bool(true) }
         is(BitPat("b???1")) { io.out := Bool(true) }
       }
     }

--- a/src/test/scala/BitsTest.scala
+++ b/src/test/scala/BitsTest.scala
@@ -46,7 +46,7 @@ class BitsSuite extends TestSuite {
   @Test def testExtractConstantFixed() {
     class Dummy extends Module {
       val io = UInt(INPUT, 0)
-      val res = UInt(5)(0)
+      val res = 5.U(0)
       assertTrue( res.getWidth == 1 )
       assertTrue( res.litValue() == 1 )
     }
@@ -57,7 +57,7 @@ class BitsSuite extends TestSuite {
   @Test def testExtractConstantRangeFixed() {
     class Dummy extends Module {
       val io = UInt(INPUT, 0)
-      val res = UInt(5)((1, 0))
+      val res = 5.U((1, 0))
       assertTrue( res.getWidth == 2 )
     }
     val dummyInst = Module(new Dummy)

--- a/src/test/scala/Chisel3Compatibility.scala
+++ b/src/test/scala/Chisel3Compatibility.scala
@@ -166,7 +166,7 @@ class Chisel3CompatibilitySuite extends TestSuite {
 
       // The following should pass without a Wire wrapper.
       val foo = Reg(Bits(width = 16))
-      foo(0) := UInt(1)
+      foo(0) := 1.U
       io.out := foo
     }
 


### PR DESCRIPTION
This change allows chisel 2 to define literals using the new Chisel 3 notation
UInt(7) => 7.U
With this change we can change the tutorials to use the new idiom, and keep the tutorial runnable on either Chisel 2 or Chisel 3 without modification