### PR TITLE
Use Seq, not Iterable, when order matters

### DIFF
--- a/src/main/scala/ChiselUtil.scala
+++ b/src/main/scala/ChiselUtil.scala
@@ -217,7 +217,7 @@ object UIntToOH
   */
 object Mux1H
 {
-  def apply[T <: Data](sel: Iterable[Bool], in: Iterable[T]): T = {
+  def apply[T <: Data](sel: Seq[Bool], in: Seq[T]): T = {
     if (in.tail.isEmpty) in.head
     else {
       val masked = (sel, in).zipped map ((s, i) => Mux(s, i.toBits, Bits(0)))
@@ -225,10 +225,10 @@ object Mux1H
     }
   }
   def apply[T <: Data](in: Iterable[(Bool, T)]): T = {
-    val (sel, data) = in.unzip
+    val (sel, data) = in.toSeq.unzip
     apply(sel, data)
   }
-  def apply[T <: Data](sel: Bits, in: Iterable[T]): T =
+  def apply[T <: Data](sel: Bits, in: Seq[T]): T =
     apply((0 until in.size).map(sel(_)), in)
   def apply(sel: Bits, in: Bits): Bool = (sel & in).orR
 }
@@ -707,15 +707,15 @@ object Pipe
   */
 object PriorityMux
 {
-  def apply[T <: Data](in: Iterable[(Bool, T)]): T = {
+  def apply[T <: Data](in: Seq[(Bool, T)]): T = {
     if (in.size == 1) {
       in.head._2
     } else {
       Mux(in.head._1, in.head._2, apply(in.tail))
     }
   }
-  def apply[T <: Data](sel: Iterable[Bool], in: Iterable[T]): T = apply(sel zip in)
-  def apply[T <: Data](sel: Bits, in: Iterable[T]): T = apply((0 until in.size).map(sel(_)), in)
+  def apply[T <: Data](sel: Seq[Bool], in: Seq[T]): T = apply(sel zip in)
+  def apply[T <: Data](sel: Bits, in: Seq[T]): T = apply((0 until in.size).map(sel(_)), in)
 }
 
 /** Returns a bit vector in which only the least-significant 1 bit in

--- a/src/main/scala/Data.scala
+++ b/src/main/scala/Data.scala
@@ -160,7 +160,7 @@ abstract class Data extends Node {
 
   protected def colonEquals(that: Bits): Unit = illegalAssignment(that)
   protected def colonEquals(that: Bundle): Unit = illegalAssignment(that)
-  protected def colonEquals[T <: Data](that: Iterable[T]): Unit = illegalAssignment(that)
+  protected def colonEquals[T <: Data](that: Seq[T]): Unit = illegalAssignment(that)
 
   protected def illegalAssignment(that: Any): Unit =
     ChiselError.error(":= not defined on " + this.getClass + " and " + that.getClass)

--- a/src/main/scala/Log2.scala
+++ b/src/main/scala/Log2.scala
@@ -48,7 +48,7 @@ object Log2 {
   */
 object PriorityEncoder
 {
-  def apply(in: Iterable[Bool]): UInt = PriorityMux(in, (0 until in.size).map(UInt(_)))
+  def apply(in: Seq[Bool]): UInt = PriorityMux(in, (0 until in.size).map(UInt(_)))
   def apply(in: Bits): UInt = UInt().asTypeFor(new PriorityEncoder(in))
 }
 

--- a/src/main/scala/Node.scala
+++ b/src/main/scala/Node.scala
@@ -298,7 +298,7 @@ abstract class Node extends Nameable {
     * @param widthfunc the function to use to calculate the width of the node
     * @param ins Nodes that are inputs to this node
     */
-  def initOf (n: String, widthfunc: (=> Node) => Width, ins: Iterable[Node]): Node = {
+  def initOf (n: String, widthfunc: (=> Node) => Width, ins: Seq[Node]): Node = {
     name = n
     inferWidth = widthfunc
     inputs ++= ins

--- a/src/main/scala/Parameters.scala
+++ b/src/main/scala/Parameters.scala
@@ -60,7 +60,6 @@
 
 package Chisel
 
-import scala.collection.immutable.{Seq=>Seq, Iterable=>Iterable}
 import scala.{collection=>readonly}
 import scala.collection.mutable
 

--- a/src/main/scala/ROM.scala
+++ b/src/main/scala/ROM.scala
@@ -40,18 +40,18 @@ object ROM {
     * @param elts any number of data objects for the ROM */
   def apply[T <: Data](elt0: T, elts: T*): ROM[T] = apply(elt0 +: elts.toSeq)
   /** @param elts any number of data objects for the ROM */
-  def apply[T <: Data](elts: Iterable[T]): ROM[T] = apply(elts.toSeq.zipWithIndex.map { case(z,i) => i -> z })
+  def apply[T <: Data](elts: Seq[T]): ROM[T] = apply(elts.toSeq.zipWithIndex.map { case(z,i) => i -> z })
   /** @param elt0 the first data object at address 0 in the ROM
     * @param elts any number of data objects for the ROM */
   def apply[T <: Data](elt0: (Int, T), elts: (Int, T)*): ROM[T] = apply(elt0 +: elts.toSeq)
   /** @param elts any number of data objects for the ROM
     * @param n optionally force the size of the ROM */
-  def apply[T <: Data](elts: Seq[(Int, T)], n: Option[Int]): ROM[T] = new ROM(SortedMap(elts:_*), n)
+  def apply[T <: Data](elts: Iterable[(Int, T)], n: Option[Int]): ROM[T] = new ROM(SortedMap(elts.toSeq:_*), n)
   /** @param elts any number of data objects for the ROM
     * @param n optionally force the size of the ROM */
-  def apply[T <: Data](elts: Seq[(Int, T)], n: Int): ROM[T] = apply(elts, Some(n))
+  def apply[T <: Data](elts: Iterable[(Int, T)], n: Int): ROM[T] = apply(elts, Some(n))
   /** @param elts any number of data objects for the ROM */
-  def apply[T <: Data](elts: Seq[(Int, T)]): ROM[T] = apply(elts, None)
+  def apply[T <: Data](elts: Iterable[(Int, T)]): ROM[T] = apply(elts, None)
   /** @param elts any number of data objects for the ROM */
   def apply[T <: Data](elts: Array[(Int, T)]): ROM[T] = apply(elts.toSeq, None)
   /** @param elts any number of data objects for the ROM

--- a/src/main/scala/Vec.scala
+++ b/src/main/scala/Vec.scala
@@ -65,7 +65,7 @@ object Vec {
 
   /** Returns a new *Vec* from a sequence of *Data* nodes.
     */
-  def apply[T <: Data](elts: Iterable[T]): Vec[T] = {
+  def apply[T <: Data](elts: Seq[T]): Vec[T] = {
     val res =
       if (!elts.isEmpty && elts.forall(_.isLit)) ROM(elts)
       else new Vec[T](i => elts.head.cloneType, elts)
@@ -103,7 +103,7 @@ object Vec {
   def apply[T <: Data](n: Int, gen: => T): Vec[T] = fill(n)(gen)
 }
 
-class VecProc(enables: Iterable[Bool], elms: Iterable[Data]) extends proc {
+class VecProc(enables: Seq[Bool], elms: Seq[Data]) extends proc {
   override def procAssign(src: Node): Unit = {
     for ((en, elm) <- enables zip elms) when (en) {
       elm.comp match {
@@ -114,7 +114,7 @@ class VecProc(enables: Iterable[Bool], elms: Iterable[Data]) extends proc {
   }
 }
 
-class Vec[T <: Data](val gen: (Int) => T, elts: Iterable[T]) extends Aggregate with VecLike[T] with Cloneable {
+class Vec[T <: Data](val gen: (Int) => T, elts: Seq[T]) extends Aggregate with VecLike[T] with Cloneable {
   val self = elts.toVector
   if (self != null && !self.isEmpty && self(0).getNode.isInstanceOf[Reg]) {
     ChiselError.check("Chisel3 compatibility: Vec(Reg) is deprecated. Please use Reg(Vec)", Version("3.0"))
@@ -186,9 +186,9 @@ class Vec[T <: Data](val gen: (Int) => T, elts: Iterable[T]) extends Aggregate w
     }
   }
   def <>(src: Vec[T]) { (self zip src) foreach {case (s, o) => s <> o} }
-  def <>(src: Iterable[T]) { (self zip src) foreach {case (s, o) => s <> o} }
+  def <>(src: Seq[T]) { (self zip src) foreach {case (s, o) => s <> o} }
 
-  override protected def colonEquals[T <: Data](that: Iterable[T]): Unit = comp match {
+  override protected def colonEquals[T <: Data](that: Seq[T]): Unit = comp match {
     case Some(p) => p procAssign Vec(that)
     case None => {
       def unidirectional[U <: Data](who: Iterable[(String, Bits)]) =
@@ -208,8 +208,8 @@ class Vec[T <: Data](val gen: (Int) => T, elts: Iterable[T]) extends Aggregate w
   override protected def colonEquals(that: Bits): Unit = {
     for (i <- 0 until length) this(i) := that(i)
   }
-  // We need this special := because Iterable[T] is not a Data.
-  def :=[T <: Data](that: Iterable[T]): Unit = colonEquals(that)
+  // We need this special := because Seq[T] is not a Data.
+  def :=[T <: Data](that: Seq[T]): Unit = colonEquals(that)
   override def removeTypeNodes { self foreach (_.removeTypeNodes) }
   override def flip: this.type = { self foreach (_.flip) ; this }
 


### PR DESCRIPTION
Iterable does not guarantee any particular ordering, whereas Seq does.
It should not be used when ordering actually matters.

This is technically an API-breaking change, but code that was relying on
it was kind of wrong, and would break in Chisel3 anyway.