### PR TITLE
Return Seq, not Vec, from PriorityEncoderOH

### DIFF
--- a/src/main/scala/ChiselUtil.scala
+++ b/src/main/scala/ChiselUtil.scala
@@ -727,9 +727,9 @@ object PriorityEncoderOH
     val outs = Vec.tabulate(in.size)(i => UInt(BigInt(1) << i, in.size))
     PriorityMux(in :+ Bool(true), outs :+ UInt(0, in.size))
   }
-  def apply(in: Seq[Bool]): Vec[Bool] = {
+  def apply(in: Seq[Bool]): Seq[Bool] = {
     val enc = encode(in)
-    Vec.tabulate(in.size)(enc(_))
+    Seq.tabulate(in.size)(enc(_))
   }
   def apply(in: Bits): UInt = encode((0 until in.getWidth).map(i => in(i)))
 }


### PR DESCRIPTION
The return type actually used to be Seq, but it was inadvertently changed
to Vec at some point.

It doesn't really make sense to create a one-hot result then follow it
with a decoder.  It's more performant to use a PriorityEncoder followed
by a comparator.  Discourage the former by returning Seq, not Vec.