### PR TITLE
Invalid verilog generated with constant idx into ROM

### DIFF
--- a/src/main/scala/BlackBox.scala
+++ b/src/main/scala/BlackBox.scala
@@ -90,7 +90,7 @@ class VerilogParameters {
   * // Implement functionality of DSP to allow simulation verification
   * } }}}
   */
-abstract class BlackBox extends Module {
+abstract class BlackBox( bbClock: Option[Clock] = None, bbReset: Option[Bool] = None) extends Module( bbClock, bbReset ) {
   Driver.blackboxes += this
   private val clockMapping = new HashMap[String, String]
 

--- a/src/main/scala/Verilog.scala
+++ b/src/main/scala/Verilog.scala
@@ -316,6 +316,18 @@ class VerilogBackend extends Backend {
 
   def emitDecReg(node: Node): String = emitDecBase(node, "reg ")
 
+  def emitDecRom( node : ROMRead ) : String = {
+    if ( node.inputs.size == 2 &&
+      node.inputs(0).isInstanceOf[Literal] &&
+      node.inputs(1).isInstanceOf[ROMData]
+    ) {
+      val idx = node.inputs(0).asInstanceOf[Literal].value.toInt
+      val litNode = node.inputs(1).asInstanceOf[ROMData].sparseLits(idx)
+      s"  reg ${emitWidth(node)} ${emitRef(node)} = ${emitRef(litNode)};\n"
+    } else
+      emitDecReg( node )
+  }
+
   override def emitDec(node: Node): String = {
     val gotWidth = node.needWidth()
     val res =
@@ -331,8 +343,8 @@ class VerilogBackend extends Backend {
       case _: Sprintf =>
         emitDecReg(node)
 
-      case _: ROMRead =>
-        emitDecReg(node)
+      case r: ROMRead =>
+        emitDecRom(r)
 
       case m: Mem[_] if !m.isInline => ""
       case m: Mem[_] =>

--- a/src/test/resources/BlackBoxSuite_UserMod_1.v
+++ b/src/test/resources/BlackBoxSuite_UserMod_1.v
@@ -1,0 +1,15 @@
+module BlackBoxSuite_UserMod_1(
+    input [3:0] io_in,
+    output[3:0] io_out
+);
+
+  wire[3:0] userbb_out;
+
+
+  assign io_out = userbb_out;
+  UserBB userbb(
+       .in( io_in ),
+       .out( userbb_out )
+  );
+endmodule
+

--- a/src/test/resources/BlackBoxSuite_UserMod_2.v
+++ b/src/test/resources/BlackBoxSuite_UserMod_2.v
@@ -1,0 +1,35 @@
+module BlackBoxSuite_UserMod_2(input clk, input usrClk, input reset,
+    input [3:0] io_in,
+    output[3:0] io_out
+);
+
+  reg [3:0] inDelay;
+  wire[3:0] T0;
+  wire[3:0] userbb_out;
+
+`ifndef SYNTHESIS
+// synthesis translate_off
+  integer initvar;
+  initial begin
+    #0.002;
+    inDelay = {1{$random}};
+  end
+// synthesis translate_on
+`endif
+
+  assign T0 = reset ? 4'h0 : io_in;
+  assign io_out = userbb_out;
+  UserClockedBB userbb(.clkIn(usrClk), .rst(reset),
+       .in( inDelay ),
+       .out( userbb_out )
+  );
+
+  always @(posedge clk) begin
+    if(reset) begin
+      inDelay <= 4'h0;
+    end else begin
+      inDelay <= io_in;
+    end
+  end
+endmodule
+

--- a/src/test/resources/VecSuite_UserMod_1.v
+++ b/src/test/resources/VecSuite_UserMod_1.v
@@ -1,0 +1,25 @@
+module VecSuite_UserMod_1(
+    input [3:0] io_in,
+    output[3:0] io_out
+);
+
+  reg [3:0] T0 = 4'h5;
+
+
+  assign io_out = T0;
+  always @(*) case (2'h2)
+    0: T0 = 4'h3;
+    1: T0 = 4'h1;
+    2: T0 = 4'h5;
+    3: T0 = 4'h8;
+    default: begin
+      T0 = 4'bx;
+`ifndef SYNTHESIS
+// synthesis translate_off
+      T0 = {1{$random}};
+// synthesis translate_on
+`endif
+    end
+  endcase
+endmodule
+

--- a/src/test/scala/BlackBoxSuite.scala
+++ b/src/test/scala/BlackBoxSuite.scala
@@ -1,0 +1,72 @@
+
+import org.junit.Assert._
+import org.junit.Test
+import org.junit.Ignore
+
+import Chisel._
+
+class BlackBoxSuite extends TestSuite {
+
+  class UserBB extends BlackBox {
+    val io = new Bundle {
+      val in = UInt( INPUT, 4 )
+      val out = UInt( OUTPUT, 4 )
+    }
+    io.in.setName("in")
+    io.out.setName("out")
+    setModuleName("UserBB")
+    io.out := io.in
+  }
+
+  class UserClockedBB( clkIn : Clock ) extends BlackBox( bbClock = clkIn ) {
+    val io = new Bundle {
+      val in = UInt( INPUT, 4 )
+      val out = UInt( OUTPUT, 4 )
+    }
+    io.in.setName("in")
+    io.out.setName("out")
+    setModuleName("UserClockedBB")
+    io.out := Reg( init = UInt(0, 4), next = io.in )
+    renameClock( clkIn, "clkIn" )
+    renameReset("rst")
+  }
+
+  @Test def userBBTest {
+
+    class UserMod extends Module {
+      val io = new Bundle {
+        val in = UInt( INPUT, 4 )
+        val out = UInt( OUTPUT, 4 )
+      }
+      val userbb = Module( new UserBB )
+      userbb.io <> io
+    }
+
+    chiselMain(Array[String]("--backend", "v",
+      "--targetDir", dir.getPath.toString()),
+      () => Module(new UserMod))
+    assertFile("BlackBoxSuite_UserMod_1.v")
+  }
+
+  @Test def userClockedBBTest {
+
+    class UserMod extends Module {
+      val io = new Bundle {
+        val in = UInt( INPUT, 4 )
+        val out = UInt( OUTPUT, 4 )
+      }
+      val inDelay = Reg( init = UInt( 0, 4 ), next = io.in )
+      val usrClk = Clock( src = clock, period = 2 )
+      usrClk.setName("usrClk")
+      val userbb = Module( new UserClockedBB( usrClk ) )
+      userbb.io.in := inDelay
+      io.out := userbb.io.out
+    }
+
+    chiselMain(Array[String]("--backend", "v",
+      "--targetDir", dir.getPath.toString()),
+      () => Module(new UserMod))
+    assertFile("BlackBoxSuite_UserMod_2.v")
+  }
+
+}

--- a/src/test/scala/VecApp.scala
+++ b/src/test/scala/VecApp.scala
@@ -68,4 +68,27 @@ class VecSuite extends TestSuite {
     assertFalse(ChiselError.hasErrors)
     
   }
+
+  @Test def constVecTest {
+    class UserMod( testCond : Boolean ) extends Module {
+      val io = new Bundle {
+        val in = UInt( INPUT, 4 )
+        val out = UInt( OUTPUT, 4 )
+      }
+      val myVec = Vec( List( UInt( 3, 4 ), UInt( 1, 4 ), UInt( 5, 4 ), UInt( 8, 4 ) ) )
+      val idx = {
+        if ( testCond )
+          UInt( 2, 4 )
+        else
+          io.in
+      }
+      io.out := myVec(idx)
+    }
+
+    chiselMain(Array[String]("--backend", "v",
+      "--targetDir", dir.getPath.toString()),
+      () => Module(new UserMod(true)))
+    assertFile("VecSuite_UserMod_1.v")
+  }
+
 }


### PR DESCRIPTION
With the following verilog, the always @(*) is interpreted as trigger on all input changes. However as there are no inputs, this never triggers. Hence it has the value xxx. This pr is a bit hacky but gets round it by changing the declaration to set the reg to an initial value.

```verilog
 reg [3:0] T0;
 always @(*) case (2'h2)
    0: T0 = 4'h3;
    1: T0 = 4'h1;
    2: T0 = 4'h5;
    3: T0 = 4'h8;
    default: begin
      T0 = 4'bx;
`ifndef SYNTHESIS
// synthesis translate_off
      T0 = {1{$random}};
// synthesis translate_on
`endif
    end
  endcase
```

instead have
```verilog
reg [3:0] T0 = 4'h5;
```