### PR TITLE
Invalid verilog generated with constant idx into ROM

### DIFF
--- a/src/main/scala/Verilog.scala
+++ b/src/main/scala/Verilog.scala
@@ -316,6 +316,18 @@ class VerilogBackend extends Backend {
 
   def emitDecReg(node: Node): String = emitDecBase(node, "reg ")
 
+  def emitDecRom( node : ROMRead ) : String = {
+    if ( node.inputs.size == 2 &&
+      node.inputs(0).isInstanceOf[Literal] &&
+      node.inputs(1).isInstanceOf[ROMData]
+    ) {
+      val idx = node.inputs(0).asInstanceOf[Literal].value.toInt
+      val litNode = node.inputs(1).asInstanceOf[ROMData].sparseLits(idx)
+      s"  reg ${emitWidth(node)} ${emitRef(node)} = ${emitRef(litNode)};\n"
+    } else
+      emitDecReg( node )
+  }
+
   override def emitDec(node: Node): String = {
     val gotWidth = node.needWidth()
     val res =
@@ -331,8 +343,8 @@ class VerilogBackend extends Backend {
       case _: Sprintf =>
         emitDecReg(node)
 
-      case _: ROMRead =>
-        emitDecReg(node)
+      case r: ROMRead =>
+        emitDecRom(r)
 
       case m: Mem[_] if !m.isInline => ""
       case m: Mem[_] =>

--- a/src/test/resources/VecSuite_UserMod_1.v
+++ b/src/test/resources/VecSuite_UserMod_1.v
@@ -1,0 +1,25 @@
+module VecSuite_UserMod_1(
+    input [3:0] io_in,
+    output[3:0] io_out
+);
+
+  reg [3:0] T0 = 4'h5;
+
+
+  assign io_out = T0;
+  always @(*) case (2'h2)
+    0: T0 = 4'h3;
+    1: T0 = 4'h1;
+    2: T0 = 4'h5;
+    3: T0 = 4'h8;
+    default: begin
+      T0 = 4'bx;
+`ifndef SYNTHESIS
+// synthesis translate_off
+      T0 = {1{$random}};
+// synthesis translate_on
+`endif
+    end
+  endcase
+endmodule
+

--- a/src/test/scala/VecApp.scala
+++ b/src/test/scala/VecApp.scala
@@ -68,4 +68,27 @@ class VecSuite extends TestSuite {
     assertFalse(ChiselError.hasErrors)
     
   }
+
+  @Test def constVecTest {
+    class UserMod( testCond : Boolean ) extends Module {
+      val io = new Bundle {
+        val in = UInt( INPUT, 4 )
+        val out = UInt( OUTPUT, 4 )
+      }
+      val myVec = Vec( List( UInt( 3, 4 ), UInt( 1, 4 ), UInt( 5, 4 ), UInt( 8, 4 ) ) )
+      val idx = {
+        if ( testCond )
+          UInt( 2, 4 )
+        else
+          io.in
+      }
+      io.out := myVec(idx)
+    }
+
+    chiselMain(Array[String]("--backend", "v",
+      "--targetDir", dir.getPath.toString()),
+      () => Module(new UserMod(true)))
+    assertFile("VecSuite_UserMod_1.v")
+  }
+
 }


### PR DESCRIPTION
With the following verilog, the always @(*) is interpreted as trigger on all input changes. However as there are no inputs, this never triggers. Hence it has the value xxx. This pr is a bit hacky but gets round it by changing the declaration to set the reg to an initial value.

```verilog
reg [3:0] T0;
 always @(*) case (2'h2)
    0: T0 = 4'h3;
    1: T0 = 4'h1;
    2: T0 = 4'h5;
    3: T0 = 4'h8;
    default: begin
      T0 = 4'bx;
`ifndef SYNTHESIS
// synthesis translate_off
      T0 = {1{$random}};
// synthesis translate_on
`endif
    end
  endcase
```

instead have
```verilog
reg [3:0] T0 = 4'h5;
```