### PR TITLE
Wide rom fix

### DIFF
--- a/src/main/scala/Cpp.scala
+++ b/src/main/scala/Cpp.scala
@@ -1223,7 +1223,7 @@ class CppBackend extends Backend {
         // Ensure they're in the constant pool if we're generating one.
         // NOTE: We call emitInit() only for its side-effects (allocating constants to the constant pool if the latter is enabled).
         // We throw away the generated intialization strings created during this invocation.
-        // We'll accumulate and output them later (aftet the constants have been assigned their values).
+        // We'll accumulate and output them later (after the constants have been assigned their values).
         def collectConstants(): Unit = {
           Driver.orderedNodes foreach (emitInit(_))
         }

--- a/src/main/scala/Cpp.scala
+++ b/src/main/scala/Cpp.scala
@@ -175,14 +175,9 @@ class CppBackend extends Backend {
       case x: Binding => List()
       case l: Literal if isInObject(l) && words(l) > 1 =>
         // Are we maintaining a constant pool?
+        // If yes, we'll output it separately.
         if (coalesceConstants) {
-          // Is this the node that actually defines the constant?
-          // If so, output the definition (we must do this only once).
-          if (constantPool.contains((l.name, l.width_)) && constantPool((l.name, l.width_)) == l) {
-            List((s"  static const val_t", s"T${l.emitIndex}[${words(l)}]"))
-          } else {
-            List()
-          }
+          List()
         } else {
           List((s"  static const val_t", s"T${l.emitIndex}[${words(l)}]"))
         }
@@ -1121,6 +1116,10 @@ class CppBackend extends Backend {
         val bMem = b.isInstanceOf[Mem[_]] || b.isInstanceOf[ROMData]
         aMem < bMem || aMem == bMem && a.needWidth() < b.needWidth()
       }
+      // If we have a constant pool, output it.
+      for (((_, _),l) <- constantPool) {
+        out_h.write(s"  static const val_t T${l.emitIndex}[${words(l)}];\n")
+      }
       // Header declarations should be unique, add a simple check
       for (m <- Driver.orderedNodes.filter(_.isInObject).sortWith(headerOrderFunc)) {
         assertUnique(emitDec(m), "redeclaration in header for nodes")
@@ -1220,6 +1219,13 @@ class CppBackend extends Backend {
       // If we're putting literals in the class as static const's,
       // generate the code to initialize them here.
       if (multiwordLiteralInObject) {
+        // The ROM init code may generate multi-word constants.
+        // Ensure they're in the constant pool if we're generating one.
+        // NOTE: We call emitInit() only for its side-effects (allocating constants to the constant pool if the latter is enabled).
+        // We throw away the generated intialization strings.
+        def collectConstants(): Unit = {
+          Driver.orderedNodes foreach (emitInit(_))
+        }
         // Emit code to assign static const literals.
         def emitConstAssignment(l: Literal): String = {
           s"const val_t ${c.name}_t::T${l.emitIndex}[] = {" + (0 until words(l)).map(emitLitVal(l, _)).reduce(_ + ", " + _) + "};\n"
@@ -1227,6 +1233,8 @@ class CppBackend extends Backend {
         var wroteAssignments = false
         // Get the literals from the constant pool (if we're using one) ...
         if (coalesceConstants) {
+          // Ensure any constants we will use are accounted for.
+          collectConstants()
           for (((v,w),l) <- constantPool) {
             writeCppFile(emitConstAssignment(l))
             wroteAssignments = true

--- a/src/main/scala/Cpp.scala
+++ b/src/main/scala/Cpp.scala
@@ -1116,7 +1116,7 @@ class CppBackend extends Backend {
         val bMem = b.isInstanceOf[Mem[_]] || b.isInstanceOf[ROMData]
         aMem < bMem || aMem == bMem && a.needWidth() < b.needWidth()
       }
-      // If we have a constant pool, output it.
+      // If we have a constant pool, output its definitions.
       for (((_, _),l) <- constantPool) {
         out_h.write(s"  static const val_t T${l.emitIndex}[${words(l)}];\n")
       }
@@ -1222,7 +1222,8 @@ class CppBackend extends Backend {
         // The ROM init code may generate multi-word constants.
         // Ensure they're in the constant pool if we're generating one.
         // NOTE: We call emitInit() only for its side-effects (allocating constants to the constant pool if the latter is enabled).
-        // We throw away the generated intialization strings.
+        // We throw away the generated intialization strings created during this invocation.
+        // We'll accumulate and output them later (aftet the constants have been assigned their values).
         def collectConstants(): Unit = {
           Driver.orderedNodes foreach (emitInit(_))
         }

--- a/src/test/scala/ROM.scala
+++ b/src/test/scala/ROM.scala
@@ -1,0 +1,70 @@
+/*
+ Copyright (c) 2011 - 2016 The Regents of the University of
+ California (Regents). All Rights Reserved.  Redistribution and use in
+ source and binary forms, with or without modification, are permitted
+ provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      two paragraphs of disclaimer in the documentation and/or other materials
+      provided with the distribution.
+    * Neither the name of the Regents nor the names of its contributors
+      may be used to endorse or promote products derived from this
+      software without specific prior written permission.
+
+ IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+ SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS,
+ ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF
+ REGENTS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF
+ ANY, PROVIDED HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION
+ TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+ MODIFICATIONS.
+*/
+
+//package ChiselTests
+import org.junit.Test
+
+import Chisel._
+
+class ROMSuite extends TestSuite {
+
+  @Test def testROM() {
+    println("\ntestROM...")
+    class DUT extends Module {
+
+      val DATAWIDTH = 133
+
+      def matchLookUpRows() = {
+        val inits = (1 to 2).map(i => UInt(i, width = DATAWIDTH))
+        ROM(inits)
+      }
+
+      val io = new Bundle {
+        val m = UInt(INPUT, width = log2Up(DATAWIDTH))
+        val fState = Bits(OUTPUT, width = DATAWIDTH)
+      }
+
+      val inpBitStrReg = RegInit(Bits(0, width = DATAWIDTH))
+
+      inpBitStrReg := matchLookUpRows.read(io.m)
+      io.fState := inpBitStrReg
+    }
+
+    class DUTTester(c: DUT) extends Tester(c) {
+      poke(c.io.m, 0)
+      peek(c.inpBitStrReg)
+      step(1)
+      peek(c.inpBitStrReg)
+    }
+    val testArgs = chiselEnvironmentArguments() ++ Array("--targetDir", dir.getPath.toString(),
+      "--backend", "c", "--genHarness", "--compile", "--test", "--debug")
+    chiselMainTest(testArgs, () => Module(new DUT())){ c => new DUTTester(c) }
+  }
+}


### PR DESCRIPTION
If we're initializing wide ROMs, we may generate additional constants when we emit the initialization code. Ensure those constants make it into the constant pool (if we're using one).